### PR TITLE
View states/provinces of China, Australia, Canada and US

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Notice that most countries follow a similar straight line path, indicating that 
 
 ## Credits
 
-This interactive pulls data on COVID-19 provided by [Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19). Huge thanks to them for making this invaluable data source publicly available.
+This interactive pulls data on COVID-19 provided by [Johns Hopkins CSSE](https://github.com/CSSEGISandData/COVID-19) and <a href="https://github.com/nytimes/covid-19-data">NYTimes</a>. Huge thanks to them for making this invaluable data source publicly available.
 
 Created by [Aatish Bhatia](https://aatishb.com/) in collaboration with [Henry Reich](https://www.youtube.com/user/minutephysics).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ When plotted in this way, exponential growth is displayed as a straight line.
 
 Notice that most countries follow a similar straight line path, indicating that the growth rate is similar across countries. We're all in this together.
 
-**Tips:** Press Space (or the play button) to Play/Pause. Press +/- keys (or the slider) to see daily changes. Hover over the graph for more info. Drag cursor to zoom into graph, doubleclick to zoom back out. Use dropdown menus to switch between Confirmed Cases ↔ Deaths, or between a logarithmic ↔ linear scale. And don't forget to wash your hands!
+**Tips:** Press Space (or the play button) to Play/Pause. Press +/- keys (or the slider) to see daily changes. Hover over the graph for more info. Drag cursor to zoom into graph, doubleclick to zoom back out. Use dropdown menus to switch between Confirmed Cases ↔ Deaths, between regions, or between a logarithmic ↔ linear scale. And don't forget to wash your hands!
 
 ## Credits
 

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@
         <div v-if="covidData.length == 0" id="nodata"><span>Not enough data for these parameters.</span></div>
 
         <div id="footer">
-          Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; Data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>
+          Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; World data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; US state data provided by <a href="https://github.com/nytimes/covid-19-data">NYTimes</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>
         </div>
 
       </div>

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
           </select>
 
           <select v-model="selectedRegion" @mousedown="pause">
-            <option v-for="s in region" v-bind:value="s">
+            <option v-for="s in regions" v-bind:value="s">
               {{ s }}
             </option>
           </select>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
 
         <graph v-if="covidData.length > 0" :data="filteredCovidData" :dates="dates" :day.sync="day" :selected-data="selectedData" :scale="selectedScale" :resize="isHidden" @graph-mounted="graphMounted = true"></graph>
 
-        <div id="nav">
+        <div v-if="covidData.length > 0" id="nav">
 
           <div class="navelement">
             <img v-if="paused" @click="play" src="icons/play.svg" style="width: 3rem;">
@@ -82,6 +82,7 @@
 
         </div>
 
+        <div v-if="covidData.length == 0" id="nodata"><span>Not enough data for these parameters.</span></div>
 
         <div id="footer">
           Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; Data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>
@@ -151,7 +152,7 @@
 
 
 
-  </div>
+  </!DOCTYPE>
 
   <!-- page code -->
   <script src="vue-definitions.js"></script>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 
         </div>
 
-        <div v-if="covidData.length == 0" id="nodata"><span>Not enough data for these parameters.</span></div>
+        <div v-if="!firstLoad && covidData.length == 0" id="nodata"><span>Not enough data for these parameters.</span></div>
 
         <div id="footer">
           Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; World data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> &middot; US state data provided by <a href="https://github.com/nytimes/covid-19-data">NYTimes</a> &middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,6 @@
 
         </div>
 
-
     </div>
 
     <div id="content">
@@ -133,7 +132,6 @@
             </li>
           </ul>
 
-
         </div>
 
         <div>
@@ -144,15 +142,11 @@
 
         </div>
 
-
       </div>
-
 
     </div>
 
-
-
-  </!DOCTYPE>
+  </div>
 
   <!-- page code -->
   <script src="vue-definitions.js"></script>

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
 
       <div id="left-column">
 
-        <graph v-if="covidData.length > 0" :data="filteredCovidData" :dates="dates" :day.sync="day" :selected-data="selectedData" :scale="selectedScale" :resize="isHidden" @graph-mounted="graphMounted = true"></graph>
+        <graph v-if="covidData.length > 0" :data="filteredCovidData" :dates="dates" :day.sync="day" :selected-data="selectedData" :selected-region="selectedRegion" :scale="selectedScale" :resize="isHidden" @graph-mounted="graphMounted = true"></graph>
 
         <div v-if="covidData.length > 0" id="nav">
 

--- a/index.html
+++ b/index.html
@@ -100,6 +100,12 @@
             </option>
           </select>
 
+          <select v-model="selectedRegion" @mousedown="pause">
+            <option v-for="s in region" v-bind:value="s">
+              {{ s }}
+            </option>
+          </select>
+
           <select v-model="selectedScale" @mousedown="pause">
             <option v-for="s in scale" v-bind:value="s">
               {{ s }}
@@ -110,9 +116,9 @@
 
         <div id="countries">
 
-          <h2>Countries</h2>
+          <h2>{{regionType}}</h2>
 
-          <p>Countries with at least {{minCasesInCountry}} {{selectedData}}</p>
+          <p>{{regionType}} with at least {{minCasesInCountry}} {{selectedData}}</p>
 
           <div id="buttonwrapper">
             <button @click="deselectAll">Deselect All</button>

--- a/style.css
+++ b/style.css
@@ -259,3 +259,11 @@ select {
 select:first-child {
   margin-top: 0;
 }
+
+#nodata {
+  height: 100%;
+  display: flex;
+  align-content: center;
+  justify-content: center;
+  align-items: center;
+}

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -203,7 +203,7 @@ Vue.component('graph', {
       let ymax = Math.max(...this.filteredSlope, 50);
 
       if (this.scale == 'Logarithmic Scale') {
-        this.yrange = [1, Math.ceil(Math.log10(1.5*ymax))]
+        this.yrange = [0, Math.ceil(Math.log10(1.5*ymax))]
       } else {
         this.yrange = [-Math.pow(10,Math.floor(Math.log10(ymax))-2), Math.round(1.05 * ymax)];
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -201,9 +201,15 @@ Vue.component('graph', {
 
     setyrange() {
       let ymax = Math.max(...this.filteredSlope, 50);
+      let ymin = Math.min(...this.filteredSlope);
 
       if (this.scale == 'Logarithmic Scale') {
-        this.yrange = [0, Math.ceil(Math.log10(1.5*ymax))]
+        if (ymin < 10) {
+          // shift ymin on log scale when fewer than 10 cases
+          this.yrange = [0, Math.ceil(Math.log10(1.5*ymax))]
+        } else {
+          this.yrange = [1, Math.ceil(Math.log10(1.5*ymax))]
+        }
       } else {
         this.yrange = [-Math.pow(10,Math.floor(Math.log10(ymax))-2), Math.round(1.05 * ymax)];
       }
@@ -511,7 +517,7 @@ let app = new Vue({
       this.countries = this.covidData.map(e => e.country).sort();
       const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
       const notableCountries = ['China', 'India', 'US', // Top 3 by population
-          'South Korea', 'Singapore', 'Japan', // Observed success so far
+          'South Korea', 'Japan', // Observed success so far
           'Canada', 'Australia']; // These appear in the region selector
 
       // TODO: clean this logic up later

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -1,7 +1,7 @@
 // custom graph component
 Vue.component('graph', {
 
-  props: ['data', 'dates', 'day', 'selectedData', 'scale', 'resize'],
+  props: ['data', 'dates', 'day', 'selectedData', 'selectedRegion', 'scale', 'resize'],
 
   template: '<div ref="graph" id="graph" style="height: 100%;"></div>',
 
@@ -236,6 +236,11 @@ Vue.component('graph', {
 
     selectedData() {
       //console.log('selected data change detected');
+      this.$emit('update:day', this.dates.length);
+    },
+
+    selectedRegion() {
+      //console.log('selected region change detected');
       this.$emit('update:day', this.dates.length);
     },
 
@@ -672,7 +677,7 @@ let app = new Vue({
 
     regions: ['World', 'US', 'China', 'Australia', 'Canada'],
 
-    selectedRegion: "World",
+    selectedRegion: 'World',
 
     sliderSelected: false,
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -314,6 +314,13 @@ let app = new Vue({
 
       }
 
+      if (urlParameters.has('region')) {
+        let myRegion = urlParameters.get('region');
+        if (this.region.includes(myRegion)) {
+          this.selectedRegion = myRegion;
+        }
+      }
+
       if (urlParameters.has('country')) {
         this.selectedCountries = urlParameters.getAll('country');
       }
@@ -575,6 +582,10 @@ let app = new Vue({
 
       if (this.selectedData == 'Reported Deaths') {
         queryUrl.append('data', 'deaths');
+      }
+
+      if (this.selectedRegion != 'World') {
+        queryUrl.append('region', this.selectedRegion);
       }
 
       for (let country of this.countries) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -480,9 +480,10 @@ let app = new Vue({
         }
       }
 
-      this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry).sort((a, b) => b.maxCases - a.maxCases);
-      this.countries = this.covidData.map(e => e.country);
-      this.selectedCountries = this.countries.slice(0, 15);
+      this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry);
+      this.countries = this.covidData.map(e => e.country).sort();
+      const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 15).map(e => e.country);
+      this.selectedCountries = this.countries.filter(e => topCountries.includes(e));
       for (const notableCountry of ['China', 'South Korea', 'Japan', 'Singapore', 'Qatar']) {
         if (!this.selectedCountries.includes(notableCountry)) {
           this.selectedCountries.push(notableCountry);

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -521,7 +521,7 @@ let app = new Vue({
 
         this.paused = false;
         this.icon = 'icons/pause.svg';
-        this.increment();
+        setTimeout(this.increment, 200);
 
       } else {
         this.paused = true;
@@ -640,7 +640,7 @@ let app = new Vue({
     minDay() {
       let minDay = this.myMin(...(this.filteredCovidData.map(e => e.slope.findIndex(f => f > 0)).filter(x => x != -1)));
       if (isFinite(minDay) && !isNaN(minDay)){
-        return minDay;
+        return minDay + 1;
       } else {
         return -1;
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -635,7 +635,18 @@ let app = new Vue({
     },
 
     regionType() {
-      return this.selectedRegion == 'World' ? 'Country' : 'Region';
+      switch (this.selectedRegion) {
+        case 'World':
+          return 'Country';
+        case 'Australia':
+        case 'United States':
+          return 'State';
+        case 'China':
+        case 'Canada':
+          return 'Province';
+        default:
+          return 'Region';
+      }
     }
   },
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -523,7 +523,7 @@ let app = new Vue({
       // TODO: clean this logic up later
       // expected behavior: generate/overwrite selected locations if: 1. data loaded from URL, but no selected locations are loaded. 2. data refreshed (e.g. changing region)
       // but do not overwrite selected locations if 1. selected locations loaded from URL. 2. We switch between confirmed cases <-> deaths
-      if ((this.selectedCountries.length == 0 || this.firstLoad == false) && updateSelectedCountries) {
+      if ((this.selectedCountries.length === 0 || !this.firstLoad) && updateSelectedCountries) {
         //console.log('generating new selected countries list');
         this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -225,28 +225,32 @@ Vue.component('graph', {
 
     scale() {
       //console.log('scale change detected', this.scale);
-       this.makeGraph();
+      this.makeGraph();
     },
 
     day(newDay, oldDay) {
-      //console.log('day change detected', oldDay, newDay);
-      this.updateLayout();
-      this.updateAnimation();
+      if (this.updateDate) { // avoid race condition bug where day change triggers old layout
+        //console.log('day change detected', oldDay, newDay);
+        this.updateLayout();
+        this.updateAnimation();
+      }
     },
 
     selectedData() {
       //console.log('selected data change detected');
-      this.$emit('update:day', this.dates.length);
+      this.updateDate = false;
     },
 
     selectedRegion() {
       //console.log('selected region change detected');
-      this.$emit('update:day', this.dates.length);
+      this.updateDate = false;
     },
 
     data() {
       //console.log('data change detected');
+      this.$emit('update:day', this.dates.length);
       this.makeGraph();
+      this.updateDate = true;
     }
 
   },
@@ -266,6 +270,7 @@ Vue.component('graph', {
       yrange: [],
       autosetRange: true,
       graphMounted: false,
+      updateDate: true,
       config: {
           responsive: true,
           toImageButtonOptions: {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -637,15 +637,15 @@ let app = new Vue({
     regionType() {
       switch (this.selectedRegion) {
         case 'World':
-          return 'Country';
+          return 'Countries';
         case 'Australia':
         case 'United States':
-          return 'State';
+          return 'States';
         case 'China':
         case 'Canada':
-          return 'Province';
+          return 'Provinces';
         default:
-          return 'Region';
+          return 'Regions';
       }
     }
   },

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -489,13 +489,11 @@ let app = new Vue({
 
       this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry);
       this.countries = this.covidData.map(e => e.country).sort();
-      const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 15).map(e => e.country);
-      this.selectedCountries = this.countries.filter(e => topCountries.includes(e));
-      for (const notableCountry of ['China', 'South Korea', 'Japan', 'Singapore', 'Qatar']) {
-        if (!this.selectedCountries.includes(notableCountry)) {
-          this.selectedCountries.push(notableCountry);
-        }
-      }
+      const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
+      const notableCountries = ['China', 'India', 'United States', // Top 3 by population
+          'South Korea', 'Singapore', 'Japan', // Observed success so far
+          'Canada', 'Australia']; // These appear in the region selector
+      this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
     },
 
     preprocessNYTData(data, type) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -316,7 +316,7 @@ let app = new Vue({
 
       if (urlParameters.has('region')) {
         let myRegion = urlParameters.get('region');
-        if (this.region.includes(myRegion)) {
+        if (this.regions.includes(myRegion)) {
           this.selectedRegion = myRegion;
         }
       }
@@ -670,7 +670,7 @@ let app = new Vue({
 
     selectedData: 'Confirmed Cases',
 
-    region: ['World', 'United States', 'China', 'Australia', 'Canada'],
+    regions: ['World', 'United States', 'China', 'Australia', 'Canada'],
 
     selectedRegion: "World",
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -287,7 +287,7 @@ let app = new Vue({
   el: '#root',
 
   mounted() {
-    this.pullData(this.selectedData, this.selectedRegion, /* didRegionChange */ true);
+    this.pullData(this.selectedData, this.selectedRegion, /* didRegionChange */ false);
   },
 
   created: function() {
@@ -498,7 +498,7 @@ let app = new Vue({
       const notableCountries = ['China', 'India', 'US', // Top 3 by population
           'South Korea', 'Singapore', 'Japan', // Observed success so far
           'Canada', 'Australia']; // These appear in the region selector
-      if (didRegionChange) {
+      if (didRegionChange || this.selectedCountries == null) {
         this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
       }
     },
@@ -699,7 +699,7 @@ let app = new Vue({
 
     isHidden: true,
 
-    selectedCountries: [],
+    selectedCountries: null,
 
     graphMounted: false,
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -399,7 +399,7 @@ let app = new Vue({
     },
 
     pullData(selectedData, selectedRegion, didRegionChange) {
-      if (selectedRegion != 'United States') {
+      if (selectedRegion != 'US') {
         let url;
         if (selectedData == 'Confirmed Cases') {
          url = "https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv";
@@ -409,7 +409,7 @@ let app = new Vue({
           return;
         }
         Plotly.d3.csv(url, (data) => this.processData(data, selectedRegion, didRegionChange));
-      } else { // selectedRegion == 'United States'
+      } else { // selectedRegion == 'US'
         const type = (selectedData == 'Reported Deaths') ? 'deaths' : 'cases'
         const url = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
         Plotly.d3.csv(url, (data) => this.processData(this.preprocessNYTData(data, type), selectedRegion, didRegionChange));
@@ -490,7 +490,7 @@ let app = new Vue({
       this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry);
       this.countries = this.covidData.map(e => e.country).sort();
       const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
-      const notableCountries = ['China', 'India', 'United States', // Top 3 by population
+      const notableCountries = ['China', 'India', 'US', // Top 3 by population
           'South Korea', 'Singapore', 'Japan', // Observed success so far
           'Canada', 'Australia']; // These appear in the region selector
       if (didRegionChange) {
@@ -501,7 +501,7 @@ let app = new Vue({
     preprocessNYTData(data, type) {
       let recastData = {};
       data.forEach(e => {
-        let st = recastData[e.state]  = (recastData[e.state] || {"Province/State": e.state, "Country/Region": "United States", "Lat": null, "Long": null});
+        let st = recastData[e.state]  = (recastData[e.state] || {"Province/State": e.state, "Country/Region": "US", "Lat": null, "Long": null});
         st[fixNYTDate(e.date)] = parseInt(e[type]);
       });
       return Object.values(recastData);
@@ -651,7 +651,7 @@ let app = new Vue({
         case 'World':
           return 'Countries';
         case 'Australia':
-        case 'United States':
+        case 'US':
           return 'States';
         case 'China':
         case 'Canada':
@@ -670,7 +670,7 @@ let app = new Vue({
 
     selectedData: 'Confirmed Cases',
 
-    regions: ['World', 'United States', 'China', 'Australia', 'Canada'],
+    regions: ['World', 'US', 'China', 'Australia', 'Canada'],
 
     selectedRegion: "World",
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -282,7 +282,7 @@ let app = new Vue({
   el: '#root',
 
   mounted() {
-    this.pullData(this.selectedData, this.selectedRegion);
+    this.pullData(this.selectedData, this.selectedRegion, /* didRegionChange */ true);
   },
 
   created: function() {
@@ -349,11 +349,11 @@ let app = new Vue({
 
   watch: {
     selectedData() {
-      this.pullData(this.selectedData, this.selectedRegion);
+      this.pullData(this.selectedData, this.selectedRegion, /* didRegionChange */ false);
     },
 
     selectedRegion() {
-      this.pullData(this.selectedData, this.selectedRegion);
+      this.pullData(this.selectedData, this.selectedRegion, /* didRegionChange */ true);
     },
 
     minDay() {
@@ -398,7 +398,7 @@ let app = new Vue({
       return Math.min.apply(Math, par);
     },
 
-    pullData(selectedData, selectedRegion) {
+    pullData(selectedData, selectedRegion, didRegionChange) {
       if (selectedRegion != 'United States') {
         let url;
         if (selectedData == 'Confirmed Cases') {
@@ -408,11 +408,11 @@ let app = new Vue({
         } else {
           return;
         }
-        Plotly.d3.csv(url, (data) => this.processData(data, selectedRegion));
+        Plotly.d3.csv(url, (data) => this.processData(data, selectedRegion, didRegionChange));
       } else { // selectedRegion == 'United States'
         const type = (selectedData == 'Reported Deaths') ? 'deaths' : 'cases'
         const url = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv";
-        Plotly.d3.csv(url, (data) => this.processData(this.preprocessNYTData(data, type), selectedRegion));
+        Plotly.d3.csv(url, (data) => this.processData(this.preprocessNYTData(data, type), selectedRegion, didRegionChange));
       }
     },
 
@@ -443,7 +443,7 @@ let app = new Vue({
           .map(e => ({...e, region: e["Province/State"]}));
     },
 
-    processData(data, selectedRegion) {
+    processData(data, selectedRegion, didRegionChange) {
       let dates = Object.keys(data[0]).slice(4);
       this.dates = dates;
 
@@ -493,7 +493,9 @@ let app = new Vue({
       const notableCountries = ['China', 'India', 'United States', // Top 3 by population
           'South Korea', 'Singapore', 'Japan', // Observed success so far
           'Canada', 'Australia']; // These appear in the region selector
-      this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
+      if (didRegionChange) {
+        this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
+      }
     },
 
     preprocessNYTData(data, type) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -683,6 +683,7 @@ let app = new Vue({
         case 'US':
           return 'States';
         case 'China':
+          return 'Provinces and Regions';
         case 'Canada':
           return 'Provinces';
         default:


### PR DESCRIPTION
This is a work-in-progress proposal to add the ability to show the provinces of China, Australia and Canada (these are the three contiguous countries which are broken down in the underlying data).

Sorry it includes a bit of a refactor and I had to change the behavior of the country/region selector quite a bit.  Instead of using the predefined list of default-selected countries, it now selects the top 15 by default, plus Singapore, Japan and Qatar (because they have interesting charts).  I also took the liberty to sort the country list in descending order of number of cases.  The code is still a bit messy (eg. it still refers to states as countries).

Just sending this out as a request for comment - let me know if this direction is useful.  I can take things out of this PR to make it more minimal if you want.

Demo: https://exclipy.github.io/covidtrends/

Partially resolves #5  (but the US is not covered because it's not in this data set)