### PR TITLE
Add `cursor:pointer` to `#explainer a`

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,6 +108,7 @@ p {
 #explainer a {
   text-decoration: underline;
   color: lightgoldenrodyellow;
+  cursor: pointer;
 }
 
 #explainer p {


### PR DESCRIPTION
`<a>` without `href` doesn't get `cursor:pointer` by default