### PR TITLE
Replace "Covid" with "COVID-19" as per the WHO

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <title>Covid Trends</title>
+  <title>COVID-19 Trends</title>
 
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
@@ -39,7 +39,7 @@
 
         <div id="logowrapper">
 
-          <h1><a href="https://aatishb.com/covidtrends">Covid Trends</a></h1>
+          <h1><a href="https://aatishb.com/covidtrends">COVID-19 Trends</a></h1>
 
           <div v-if="!isHidden" id="logos">
             <a href="https://aatishb.com/"><img src="logos/aatishb-bw.png" height="40"></img></a>


### PR DESCRIPTION
Name accuracy is important, even if this seems like a minor detail: https://www.who.int/emergencies/diseases/novel-coronavirus-2019/technical-guidance/naming-the-coronavirus-disease-(covid-2019)-and-the-virus-that-causes-it