### PR TITLE
add support Japan prefectures

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -432,7 +432,15 @@ let app = new Vue({
 
     pullData(selectedData, selectedRegion, updateSelectedCountries = true) {
       //console.log('pulling', selectedData, ' for ', selectedRegion);
-      if (selectedRegion != 'US') {
+      if (selectedRegion == 'Japan') {
+        let url;
+        if (selectedData == 'Confirmed Cases') {
+	    url = "https://raw.githubusercontent.com/sanpei3/covid19jp/master/time_series_covid19_confirmed_Japan.csv";
+	} else {
+	    return;
+	}
+        Plotly.d3.csv(url, (data) => this.processData(data, selectedRegion, updateSelectedCountries));
+      } else if (selectedRegion != 'US') {
         let url;
         if (selectedData == 'Confirmed Cases') {
          url = 'https://raw.githubusercontent.com/CSSEGISandData/COVID-19/master/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_global.csv';
@@ -735,6 +743,7 @@ let app = new Vue({
         case 'China':
           return 'Provinces';
         case 'Canada':
+        case 'Japan':
           return 'Provinces';
         default:
           return 'Regions';
@@ -750,7 +759,7 @@ let app = new Vue({
 
     selectedData: 'Confirmed Cases',
 
-    regions: ['World', 'US', 'China', 'Australia', 'Canada'],
+    regions: ['World', 'US', 'China', 'Australia', 'Canada', 'Japan'],
 
     selectedRegion: 'World',
 


### PR DESCRIPTION
There is no Japanese prefecture data in CSSEGISandData.
So I got permission to convert data from https://gis.jag-japan.com/covid19jp/, https://dl.dropboxusercontent.com/s/6mztoeb6xf78g5w/COVID-19.csv into CSSEGISandData format. Currently, every 30min it is automatically converted to CSSEGISandData format into https://raw.githubusercontent.com/sanpei3/covid19jp/master/time_series_covid19_confirmed_Japan.csv, this change is used.

Temporary, I created a test site as below. If this change is merged, I will remove the test site.
https://sanpei3.github.io/covidtrends/