### PR TITLE
make the number of days to look back configurable

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
     <div id="header">
 
         <div id="explainer">
-          <p>This interactive charts the <b><i>new</i></b> {{selectedData.toLowerCase()}} of COVID-19 in the past week vs. the <b><i>total</i></b> {{selectedData.toLowerCase()}} to date. When plotted in this way, exponential growth is represented as a straight line that slopes upwards. Notice that almost all countries follow a very similar path of exponential growth. <i>We're all in this together.</i> <span v-if="isHidden"><a @click="toggleHide">Learn more.</a></span></p>
+          <p>This interactive charts the <b><i>new</i></b> {{selectedData.toLowerCase()}} of COVID-19 in the past {{slopeDays}} days vs. the <b><i>total</i></b> {{selectedData.toLowerCase()}} to date. When plotted in this way, exponential growth is represented as a straight line that slopes upwards. Notice that almost all countries follow a very similar path of exponential growth. <i>We're all in this together.</i> <span v-if="isHidden"><a @click="toggleHide">Learn more.</a></span></p>
 
           <span v-if="!isHidden">
 
@@ -111,6 +111,8 @@
               {{ s }}
             </option>
           </select>
+
+          <br><br>Days to look back: {{slopeDays}} <input style="width:100%" type="range" min="1" max="14" value="7" class="slider" v-model="slopeDays">
 
         </div>
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -140,7 +140,7 @@ Vue.component('graph', {
           },
         },
         yaxis: {
-          title: 'New ' + this.selectedData + ' (in the Past Week)',
+          title: 'New ' + this.selectedData + ' (in the Past ' + this.$parent.$data.slopeDays + ' days)',
           type: this.scale == 'Logarithmic Scale' ? 'log' : 'linear',
           range: this.yrange,
           titlefont: {
@@ -388,6 +388,12 @@ let app = new Vue({
       }
     },
 
+    slopeDays() {
+      if (!this.firstLoad) {
+        this.pullData(this.selectedData, this.selectedRegion, /*updateSelectedCountries*/ false);
+      }
+    },
+
     minDay() {
       if (this.day < this.minDay) {
         this.day = this.minDay;
@@ -530,7 +536,7 @@ let app = new Vue({
           for (let date of dates) {
             arr.push(row[date]);
           }
-          let slope = arr.map((e,i,a) => e - a[i - 7]);
+          let slope = arr.map((e,i,a) => e - a[i - this.slopeDays]);
           let region = row.region
 
           if (Object.keys(renames).includes(region)) {
@@ -757,6 +763,8 @@ let app = new Vue({
     sliderSelected: false,
 
     day: 7,
+
+    slopeDays: 7,
 
     icon: 'icons/play.svg',
 


### PR DESCRIPTION
This PR lets you adjust how many days are considered when calculating the y axis data. With this you can easily see rougher or smoother lines.

Working demo: https://raw.githack.com/UoA-eResearch/covidtrends/configurable_slopeDays/