### PR TITLE
Replace object spread with Object.assign

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -516,12 +516,12 @@ let app = new Vue({
 
     filterByCountry(data, dates, selectedRegion) {
       return data.filter(e => e['Country/Region'] == selectedRegion)
-          .map(e => ({...e, region: e['Province/State']}));
+          .map(e => Object.assign({}, e, {region: e['Province/State']}));
     },
 
     convertStateToCountry(data, dates, selectedRegion) {
       return data.filter(e => e['Province/State'] == selectedRegion)
-          .map(e => ({...e, region: e['Province/State']}));
+          .map(e => Object.assign({}, e, {region: e['Province/State']}));
     },
 
     processData(data, selectedRegion, updateSelectedCountries) {


### PR DESCRIPTION
The former is the only use of ES2018 syntax in the code. Replacing
it with the equivalent ES6 function allows the code to run in more
browsers.