### PR TITLE
Tweak country name position

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -105,7 +105,7 @@ Vue.component('graph', {
         name: e.country,
         mode: 'markers+text',
         legendgroup: i,
-        textposition: 'top left',
+        textposition: 'center right',
         marker: {
           size: 6,
           color: 'rgba(254, 52, 110, 1)'


### PR DESCRIPTION
Currently a country name frequently overdrawn by other countries line because
a usual trend is to slower a growth rate over time. By moving labels after its
line makes the probability of overdraw smaller and overall readability higher.

Before
![image](https://user-images.githubusercontent.com/2743474/78821279-e1bbb880-79e1-11ea-8073-e02f9e905efb.png)


After
![image](https://user-images.githubusercontent.com/2743474/78821286-e54f3f80-79e1-11ea-9b12-8cc3dde7db56.png)

