### PR TITLE
Makes shareable link dynamic

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -681,7 +681,8 @@ let app = new Vue({
     },
 
     createURL() {
-      let baseUrl = 'https://aatishb.com/covidtrends/?';
+
+      let baseUrl = window.location.href.split('?')[0];
 
       let queryUrl = new URLSearchParams();
 
@@ -712,7 +713,7 @@ let app = new Vue({
         }
       }
 
-      let url = baseUrl + queryUrl.toString();
+      let url = baseUrl + '?' + queryUrl.toString();
 
       window.history.replaceState( {} , 'Covid Trends', '?'+queryUrl.toString() );
 


### PR DESCRIPTION
Makes shareable link dynamic based on the current url.

This change allows the shareable link to read the base URL from the current URL. This is a nice to have for folks that have forked the repo and are pushing it to their own Github pages.