### PR TITLE
Option to hide marker-labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,8 +122,8 @@
             </option>
           </select>
 
-            <input type="checkbox" style="margin-top: 0.75rem;" id="hideLabels" v-model="labelsHidden">
-            <label for="hideLabels">Hide country labels</label>
+            <input type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
+            <label for="showLabels">Show labels</label>
 
         </div>
 

--- a/index.html
+++ b/index.html
@@ -122,6 +122,9 @@
             </option>
           </select>
 
+            <input type="checkbox" style="margin-top: 0.75rem;" id="hideLabels" v-model="labelsHidden">
+            <label for="hideLabels">Hide country labels</label>
+
         </div>
 
         <div id="countries">
@@ -137,11 +140,6 @@
           <div id="buttonwrapper">
             <button @click="deselectAll">Deselect All</button>
             <button @click="selectAll">Select All</button>
-          </div>
-
-          <div id="buttonwrapper">
-            <button @click="hideLabels">Hide Labels</button>
-            <button @click="showLabels">Show Labels</button>
           </div>
 
           <ul style="padding-top: 0.5rem;">

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
       <div id="left-column">
 
-        <graph v-if="covidData.length > 0" :graph-data="graphData" :day="day" :resize="isHidden" @graph-mounted="graphMounted = true"></graph>
+        <graph v-if="covidData.length > 0" :graph-data="graphData" :day="day" :resize="isHidden" :labels-hidden="labelsHidden" @graph-mounted="graphMounted = true"></graph>
 
         <div v-if="covidData.length > 0" id="nav">
 
@@ -137,6 +137,11 @@
           <div id="buttonwrapper">
             <button @click="deselectAll">Deselect All</button>
             <button @click="selectAll">Select All</button>
+          </div>
+
+          <div id="buttonwrapper">
+            <button @click="hideLabels">Hide Labels</button>
+            <button @click="showLabels">Show Labels</button>
           </div>
 
           <ul style="padding-top: 0.5rem;">

--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
 
       <div id="left-column">
 
-        <graph v-if="covidData.length > 0" :graph-data="graphData" :day="day" :resize="isHidden" :labels-hidden="labelsHidden" @graph-mounted="graphMounted = true"></graph>
+        <graph v-if="covidData.length > 0" :graph-data="graphData" :day="day" :resize="isHidden" @graph-mounted="graphMounted = true"></graph>
 
         <div v-if="covidData.length > 0" id="nav">
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -1,7 +1,7 @@
 // custom graph component
 Vue.component('graph', {
 
-  props: ['graphData', 'day', 'resize'],
+  props: ['graphData', 'day', 'resize', 'labelsHidden'],
 
   template: '<div ref="graph" id="graph" style="height: 100%;"></div>',
 
@@ -107,6 +107,10 @@ Vue.component('graph', {
     resize() {
       Plotly.Plots.resize(this.$refs.graph);
     },
+
+    labelsHidden() {
+      this.updateGraph();
+    }
   },
 
   data() {
@@ -500,6 +504,14 @@ let app = new Vue({
       this.selectedCountries = [];
     },
 
+    hideLabels() {
+      this.labelsHidden = true;
+    },
+
+    showLabels() {
+      this.labelsHidden = false;
+    },
+
     toggleHide() {
       this.isHidden = !this.isHidden;
     },
@@ -666,7 +678,7 @@ let app = new Vue({
         y: [e.slope[this.day - 1]],
         text: e.country,
         name: e.country,
-        mode: 'markers+text',
+        mode: this.labelsHidden ? 'markers':'markers+text',
         legendgroup: i,
         textposition: 'center right',
         marker: {
@@ -760,7 +772,10 @@ let app = new Vue({
 
     visibleCountries: [],
 
+    ///explainer panel
     isHidden: true,
+
+    labelsHidden: false,
 
     selectedCountries: [],
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -666,7 +666,7 @@ let app = new Vue({
         y: [e.slope[this.day - 1]],
         text: e.country,
         name: e.country,
-        mode: this.labelsHidden ? 'markers':'markers+text',
+        mode: this.showLabels ? 'markers+text':'markers',
         legendgroup: i,
         textposition: 'center right',
         marker: {
@@ -763,7 +763,7 @@ let app = new Vue({
     ///explainer panel
     isHidden: true,
 
-    labelsHidden: false,
+    showLabels: true,
 
     selectedCountries: [],
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -1,7 +1,7 @@
 // custom graph component
 Vue.component('graph', {
 
-  props: ['graphData', 'day', 'resize', 'labelsHidden'],
+  props: ['graphData', 'day', 'resize'],
 
   template: '<div ref="graph" id="graph" style="height: 100%;"></div>',
 
@@ -107,10 +107,6 @@ Vue.component('graph', {
     resize() {
       Plotly.Plots.resize(this.$refs.graph);
     },
-
-    labelsHidden() {
-      this.updateGraph();
-    }
   },
 
   data() {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -500,14 +500,6 @@ let app = new Vue({
       this.selectedCountries = [];
     },
 
-    hideLabels() {
-      this.labelsHidden = true;
-    },
-
-    showLabels() {
-      this.labelsHidden = false;
-    },
-
     toggleHide() {
       this.isHidden = !this.isHidden;
     },


### PR DESCRIPTION
Closes #102  

Adds 2 buttons (like the the two de-/select buttons) for hiding and showing the labels. Especially useful when having more many curves in the same place...
The Text-info on hover still works obv...