### PR TITLE
Add Curve for Worldwide Stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The purpose of this fork is to provide visualizations for the
 trajectory of COVID-19 growth at a global scale. It plots a global
 trajectory as well as a trajectory for each of the continents.
 
-"The Earth is one country and mankind its citizens" ~~ Baha'u'llah
+"The Earth is but one country and mankind its citizens" ~~ Baha'u'llah
 
 ### Geographical Notes
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ trajectories include the data for Russia and Turkey (among others).  I'm open to
 
 The names of the "countries" are based on those of the original
 codebase -- they are not mine. In all cases I have avoid introducing
-any changes to names to avoid any suggestion of partiality toward any
-kind of regional or territorial dispute.
+any changes to names to avoid any suggestion of partiality toward
+any kind of regional or territorial dispute. Any changes should be
+suggested to the upstream project.
 
 ## What is this?
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
+## About this fork
+
+The purpose of this fork is to provide visualizations for the
+trajectory of COVID-19 growth at a global scale. It plots a global
+trajectory as well as a trajectory for each of the continents.
+
+"The Earth is one country and mankind its citizens" ~~ Baha'u'llah
+
+### Geographical Notes
+
+The division of locations/countries into
+continents is based on the [CIA World Facebook](
+https://www.cia.gov/library/publications/the-world-factbook/geos/xx.h
+tml). In cases where countries belong to two continents, they
+are double-counted. For example, both the 'Europe' and the 'Asia'
+trajectories include the data for Russia and Turkey (among others).  I'm open to other suggestions as well.
+
+The names of the "countries" are based on those of the original
+codebase -- they are not mine. In all cases I have avoid introducing
+any changes to names to avoid any suggestion of partiality toward any
+kind of regional or territorial dispute.
+
 ## What is this?
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-25-orange.svg?style=flat-square)](#contributors-)

--- a/index.html
+++ b/index.html
@@ -136,6 +136,16 @@
 
         <div class="countries">
 
+          <div id="continents" v-if="selectedRegion == 'World'">
+          <h2>Continents</h2>
+          <ul>
+            <li v-for="continent in continentNames">
+              <input @change="createURL" type="checkbox" :id="continent" :value="continent" v-model="selectedCountries">
+              <label :for="continent">{{continent}}</label>
+            </li>
+          </ul>
+          </div>
+          
           <h2>{{regionType}}</h2>
 
           <div class="search">

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -387,7 +387,7 @@ window.app = new Vue({
 
     // add a row to the end of the data that sums global data
     addRowForWorld(data, dates) {
-      newRow = data.reduce(this.addNumericRows(dates));
+      var newRow = data.reduce(this.addNumericRows(dates));
       newRow['Country/Region'] = 'World';
       data.push(newRow); 
     },

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -374,10 +374,30 @@ window.app = new Vue({
         .map(e => Object.assign({}, e, {region: e['Province/State']}));
     },
 
+    // returns a function that takes two arrays and adds the corresponding places together for list of dates
+    addNumericRows(dates) {
+      return function(row1, row2) {
+        newRow = {}
+        for(let date of dates) { 
+          newRow[date] = Number(row1[date]) + Number(row2[date]);
+        }
+        return newRow;
+      }
+    },
+
+    // add a row to the end of the data that sums global data
+    addRowForWorld(data, dates) {
+      newRow = data.reduce(this.addNumericRows(dates));
+      newRow['Country/Region'] = 'World';
+      data.push(newRow); 
+    },
+
     processData(data, selectedRegion, updateSelectedCountries) {
       let dates = Object.keys(data[0]).slice(4);
       this.dates = dates;
       this.day = this.dates.length;
+
+      this.addRowForWorld(data, dates)
 
       let regionsToPullToCountryLevel = ['Hong Kong', 'Macau'];
 
@@ -436,7 +456,7 @@ window.app = new Vue({
       this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry);
       this.countries = this.covidData.map(e => e.country).sort();
       this.visibleCountries = this.countries;
-      const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
+      const topCountries = this.covidData.filter((a) => a.country != 'World').sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
       const notableCountries = ['China (Mainland)', 'India', 'US', // Top 3 by population
         'South Korea', 'Japan', 'Taiwan', 'Singapore', // Observed success so far
         'Hong Kong',            // Was previously included in China's numbers

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -408,9 +408,11 @@ window.app = new Vue({
         }
       }
 
-      var newRow = selectData.reduce(this.addNumericRows(dates));
-      newRow['Country/Region'] = geography;
-      data.push(newRow); 
+      if(selectData.length > 0) {
+        var newRow = selectData.reduce(this.addNumericRows(dates));
+        newRow['Country/Region'] = geography;
+        data.push(newRow); 
+      }
     },
 
 		getContinentNames() {
@@ -649,16 +651,15 @@ window.app = new Vue({
 
       let grouped;
 
-			// add rows for world and for each continent
-      this.addRowForWorld(data, dates);
-			var geographyInfo = this.getGeographyInfo();
-		  var continentNames = this.getContinentNames();
-			for (var continent of continentNames) {
-	      this.addRowForGeography(data, dates, continent, geographyInfo[continent])
-			}
-
-
       if (selectedRegion == 'World') {
+        // add rows for world and for each continent
+        this.addRowForWorld(data, dates);
+        var geographyInfo = this.getGeographyInfo();
+        var continentNames = this.getContinentNames();
+        for (var continent of continentNames) {
+          this.addRowForGeography(data, dates, continent, geographyInfo[continent])
+        }
+
         grouped = this.groupByCountry(data, dates, regionsToPullToCountryLevel);
 
         // pull Hong Kong and Macau to Country level
@@ -711,8 +712,10 @@ window.app = new Vue({
 
       this.covidData = covidData.filter(e => e.maxCases > this.minCasesInCountry);
       this.countries = this.covidData.map(e => e.country).sort();
-      this.visibleCountries = this.countries;
-      const topCountries = this.covidData.filter((a) => a.country != 'World').sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
+      this.continentNames = this.getContinentNames()
+      this.continentNames.push("World")
+      this.visibleCountries = this.countries.filter((a) => !this.continentNames.includes(a))
+      const topCountries = this.covidData.sort((a, b) => b.maxCases - a.maxCases).slice(0, 9).map(e => e.country);
       const notableCountries = ['China (Mainland)', 'India', 'US', // Top 3 by population
         'South Korea', 'Japan', 'Taiwan', 'Singapore', // Observed success so far
         'Hong Kong',            // Was previously included in China's numbers

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -398,11 +398,12 @@ window.app = new Vue({
 
     // add a row to the end of the data that sums global data
     addRowForGeography(data, dates, geography, countries) {
-      countries = ['Spain','France','Germany','UK','Switzerland','Italy']
       selectData = []
       for(i = 0; i < data.length; i++) {
         var name = data[i]['Country/Region']
         if(countries.includes(name)) {
+          // for debugging
+				  //console.log("Adding " + name + " to " + geography + ".")
           selectData.push(data[i])
         }
       }
@@ -412,6 +413,231 @@ window.app = new Vue({
       data.push(newRow); 
     },
 
+		getContinentNames() {
+			return ["Africa","Asia","Europe","North America","South America", "Oceanica"]
+		},
+
+    getGeographyInfo() {
+      return {
+        "Africa": 
+							["Algeria",
+							 "Angola",
+							 "Benin",
+							 "Botswana",
+							 "Burkina Faso",
+							 "Burundi",
+							 "Cabo Verde",
+							 "Cameroon",
+							 "Central African Republic",
+							 "Chad",
+							 "Comoros",
+							 "Congo (Brazzaville)",
+							 "Congo (Kinshasa)",
+							 "Cote d'Ivoire",
+							 "Djibouti",
+							 "Egypt",
+							 "Equatorial Guinea",
+							 "Eritrea",
+							 "Eswatini",
+							 "Ethiopia",
+							 "Gabon",
+							 "Gambia",
+							 "Ghana",
+							 "Guinea",
+							 "Guinea-Bissau",
+							 "Kenya",
+							 "Lesotho",
+							 "Liberia",
+							 "Libya",
+							 "Madagascar",
+							 "Malawi",
+							 "Mali",
+							 "Mauritania",
+							 "Mauritius",
+							 "Morocco",
+							 "Mozambique",
+							 "Namibia",
+							 "Niger",
+							 "Nigeria",
+							 "Rwanda",
+							 "Sao Tome and Principe",
+							 "Senegal",
+							 "Seychelles",
+							 "Sierra Leone",
+							 "Somalia",
+							 "South Africa",
+							 "South Sudan",
+							 "Sudan",
+							 "Tanzania",
+							 "Togo",
+							 "Tunisia",
+							 "Uganda",
+							 "Zambia",
+							 "Zimbabwe"
+				],
+        "Asia": [
+     						"Afghanistan",
+								"Armenia",
+								"Azerbaijan*",
+								"Bahrain",
+								"Bangladesh",
+								"Bhutan",
+								"Brunei",
+								"Burma",
+								"Cambodia",
+								"China",
+								"Cyprus",
+								"Georgia",
+								"Hong Kong",
+								"India",
+								"Indonesia",
+								"Iran",
+								"Iraq",
+								"Israel",
+								"Japan",
+								"Jordan",
+								"Kazakhstan",
+								"North Korea",
+								"Korea, South",
+								"Kuwait",
+								"Kyrgyzstan",
+								"Laos",
+								"Lebanon",
+								"Malaysia",
+								"Maldives",
+								"Mongolia",
+								"Nepal",
+								"Oman",
+								"Pakistan",
+								"Philippines",
+								"Qatar",
+								"Russia",
+								"Saudi Arabia",
+								"Singapore",
+								"Sri Lanka",
+								"Syria",
+								"Taiwan*",
+								"Tajikistan",
+								"Thailand",
+								"Timor-Leste",
+								"Turkey",
+								"Turkmenistan",
+								"United Arab Emirates",
+								"Uzbekistan",
+								"Vietnam",
+								"West Bank and Gaza",
+								"Yemen"
+				],
+        "Europe": [
+              "Albania",
+              "Andorra",
+              "Austria",
+              "Azerbaijan",
+              "Belarus",
+              "Belgium",
+              "Bosnia and Herzegovina",
+              "Bulgaria",
+              "Croatia",
+              "Czechia",
+							"Czech Republic",
+              "Denmark",
+              "Estonia",
+              "Finland",
+              "France",
+              "Georgia",
+              "Germany",
+              "Greece",
+              "Holy See (Vatican City)",
+              "Hungary",
+              "Iceland",
+              "Ireland",
+              "Italy",
+              "Kazakhstan",
+              "Kosovo",
+              "Latvia",
+              "Liechtenstein",
+              "Lithuania",
+              "Luxembourg",
+              "Malta",
+              "Moldova",
+              "Monaco",
+              "Montenegro",
+              "Netherlands",
+              "North Macedonia",
+              "Norway",
+              "Poland",
+              "Portugal",
+              "Romania",
+              "Russia",
+              "San Marino",
+              "Serbia",
+              "Slovakia",
+              "Slovenia",
+              "Spain",
+              "Sweden",
+              "Switzerland",
+              "Turkey",
+              "Ukraine",
+              "United Kingdom"
+        ],
+        "North America": [
+							"Antigua and Barbuda",
+							"Bahamas",
+							"Barbados",
+							"Belize",
+							"Canada",
+							"Costa Rica",
+							"Cuba",
+							"Dominica",
+							"Dominican Republic",
+							"El Salvador",
+							"Grenada",
+							"Guatemala",
+							"Haiti",
+							"Honduras",
+							"Jamaica",
+							"Mexico",
+							"Nicaragua",
+							"Panama",
+							"Saint Kitts and Nevis",
+							"Saint Lucia",
+							"Saint Vincent and the Grenadines",
+							"Trinidad and Tobago",
+							"US"
+				],
+        "South America": [
+								"Argentina",
+								"Bolivia",
+								"Brazil",
+								"Chile",
+								"Colombia",
+								"Ecuador",
+								"Guyana",
+								"Paraguay",
+								"Peru",
+								"Suriname",
+								"Uruguay",
+								"Venezuela"
+				],
+        "Oceanica": [
+								"Australia",
+								"Fiji",
+								"Kiribati",
+								"Marshall Islands",
+								"Federated States of Micronesia",
+								"Nauru",
+								"New Zealand",
+								"Palau",
+								"Papua New Guinea",
+								"Samoa",
+								"Solomon Islands",
+								"Tonga",
+								"Tuvalu",
+								"Vanuatu"
+				]
+      }
+    },
+
 
 
     processData(data, selectedRegion, updateSelectedCountries) {
@@ -419,12 +645,18 @@ window.app = new Vue({
       this.dates = dates;
       this.day = this.dates.length;
 
-      this.addRowForWorld(data, dates);
-      this.addRowForGeography(data, dates, "Europe", ['Spain','France','Germany','UK','Switzerland','Italy'])
-
       let regionsToPullToCountryLevel = ['Hong Kong', 'Macau'];
 
       let grouped;
+
+			// add rows for world and for each continent
+      this.addRowForWorld(data, dates);
+			var geographyInfo = this.getGeographyInfo();
+		  var continentNames = this.getContinentNames();
+			for (var continent of continentNames) {
+	      this.addRowForGeography(data, dates, continent, geographyInfo[continent])
+			}
+
 
       if (selectedRegion == 'World') {
         grouped = this.groupByCountry(data, dates, regionsToPullToCountryLevel);
@@ -449,6 +681,7 @@ window.app = new Vue({
         'Korea, South': 'South Korea',
         'China': 'China (Mainland)'
       };
+
 
       let covidData = [];
       for (let row of grouped) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -377,12 +377,12 @@ window.app = new Vue({
     // returns a function that takes two arrays and adds the corresponding places together for list of dates
     addNumericRows(dates) {
       return function(row1, row2) {
-        newRow = {}
-        for(let date of dates) { 
+        var newRow = {};
+        for (let date of dates) { 
           newRow[date] = Number(row1[date]) + Number(row2[date]);
         }
         return newRow;
-      }
+      };
     },
 
     // add a row to the end of the data that sums global data
@@ -397,7 +397,7 @@ window.app = new Vue({
       this.dates = dates;
       this.day = this.dates.length;
 
-      this.addRowForWorld(data, dates)
+      this.addRowForWorld(data, dates);
 
       let regionsToPullToCountryLevel = ['Hong Kong', 'Macau'];
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -396,12 +396,31 @@ window.app = new Vue({
       data.push(newRow); 
     },
 
+    // add a row to the end of the data that sums global data
+    addRowForGeography(data, dates, geography, countries) {
+      countries = ['Spain','France','Germany','UK','Switzerland','Italy']
+      selectData = []
+      for(i = 0; i < data.length; i++) {
+        var name = data[i]['Country/Region']
+        if(countries.includes(name)) {
+          selectData.push(data[i])
+        }
+      }
+
+      var newRow = selectData.reduce(this.addNumericRows(dates));
+      newRow['Country/Region'] = geography;
+      data.push(newRow); 
+    },
+
+
+
     processData(data, selectedRegion, updateSelectedCountries) {
       let dates = Object.keys(data[0]).slice(4);
       this.dates = dates;
       this.day = this.dates.length;
 
       this.addRowForWorld(data, dates);
+      this.addRowForGeography(data, dates, "Europe", ['Spain','France','Germany','UK','Switzerland','Italy'])
 
       let regionsToPullToCountryLevel = ['Hong Kong', 'Macau'];
 


### PR DESCRIPTION
This is in response to #86.  A few folks have been requesting to see a curve with worldwide totals, and I was interested in this too!  This adds "World" to the list of countries; selecting it shows the worldwide totals.  I spent some time testing and verified that it works for both 'conformed cases' and 'reported deaths'.  Also took care to exclude the worldwide figure from the top 10 countries (which are automatically selected) so that the animation looks clean when you come to the page for the first time.

This is literally a "Hello World" pull request :D