### PR TITLE
Auto-update country URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
           </div>
 
           <div class="navelement">
-            <select @change="createURLFromChange" v-model="selectedScale" @mousedown="pause" aria-Label="Select Scale">
+            <select @change="createURL" v-model="selectedScale" @mousedown="pause" aria-Label="Select Scale">
               <option v-for="s in scale" v-bind:value="s">
                 {{ s }}
               </option>
@@ -104,30 +104,30 @@
         <div>
           <h2>Customize</h2>
           <label for="selectedData">Select Parameter</label>
-          <select @change="createURLFromRegion" id="selectedData" v-model="selectedData" @mousedown="pause">
+          <select id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">
               {{ d }}
             </option>
           </select>
           <label for="selectedRegion">Select Region</label>
-          <select @change="createURLFromRegion" id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
+          <select id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
             <option v-for="s in regions" v-bind:value="s">
               {{ s }}
             </option>
           </select>
           <label for="selectedScale">Select Scale</label>
-          <select @change="createURLFromChange" id="selectedScale" v-model="selectedScale" @mousedown="pause">
+          <select @change="createURL" id="selectedScale" v-model="selectedScale" @mousedown="pause">
             <option v-for="s in scale" v-bind:value="s">
               {{ s }}
             </option>
           </select>
-          <input @change="createURLFromChange" type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
+          <input @change="createURL" type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
           <label for="showLabels">Show Labels</label>
 
           <div>
-            <input @change="createURLFromChange" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
+            <input @change="createURL" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
             <label for="showTrendLine">Show
-              <input @change="createURLFromChange" type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
+              <input @change="createURL" type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
                Day Doubling Time</label>
           </div>
 
@@ -150,7 +150,7 @@
 
           <ul>
             <li v-for="country in visibleCountries">
-              <input @change="createURLFromChange" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
+              <input @change="createURL" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
               <label :for="country">{{country}}</label>
             </li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -82,7 +82,7 @@
           </div>
 
           <div class="navelement">
-            <select v-model="selectedScale" @mousedown="pause" aria-Label="Select Scale">
+            <select @change="createURLFromChange" v-model="selectedScale" @mousedown="pause" aria-Label="Select Scale">
               <option v-for="s in scale" v-bind:value="s">
                 {{ s }}
               </option>

--- a/index.html
+++ b/index.html
@@ -157,14 +157,6 @@
 
         </div>
 
-        <div>
-
-          <div class="buttonwrapper">
-            <button @click="createURL" @mousedown="pause">{{copied ? 'Link Copied to Clipboard!' : 'Create Shareable Link'}}</button>
-          </div>
-
-        </div>
-
       </aside>
 
     </div>

--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
 
           <ul>
             <li v-for="country in visibleCountries">
-              <input type="checkbox" :id="country" :value="country" v-model="selectedCountries">
+              <input @change="createURL" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
               <label :for="country">{{country}}</label>
             </li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
             </option>
           </select>
           <label for="selectedScale">Select Scale</label>
-          <select @change="createURLFromSelect" id="selectedScale" v-model="selectedScale" @mousedown="pause">
+          <select @change="createURLFromCheckbox" id="selectedScale" v-model="selectedScale" @mousedown="pause">
             <option v-for="s in scale" v-bind:value="s">
               {{ s }}
             </option>

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
         <div>
           <h2>Customize</h2>
           <label for="selectedData">Select Parameter</label>
-          <select @change="createURLFromChange" id="selectedData" v-model="selectedData" @mousedown="pause">
+          <select @change="createURLFromRegion" id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">
               {{ d }}
             </option>

--- a/index.html
+++ b/index.html
@@ -104,28 +104,28 @@
         <div>
           <h2>Customize</h2>
           <label for="selectedData">Select Parameter</label>
-          <select @change="createURLFromSelect" id="selectedData" v-model="selectedData" @mousedown="pause">
+          <select @change="createURLFromChange" id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">
               {{ d }}
             </option>
           </select>
           <label for="selectedRegion">Select Region</label>
-          <select @change="createURLFromSelect" id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
+          <select @change="createURLFromRegion" id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
             <option v-for="s in regions" v-bind:value="s">
               {{ s }}
             </option>
           </select>
           <label for="selectedScale">Select Scale</label>
-          <select @change="createURLFromCheckbox" id="selectedScale" v-model="selectedScale" @mousedown="pause">
+          <select @change="createURLFromChange" id="selectedScale" v-model="selectedScale" @mousedown="pause">
             <option v-for="s in scale" v-bind:value="s">
               {{ s }}
             </option>
           </select>
-          <input @change="createURLFromCheckbox" type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
+          <input @change="createURLFromChange" type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
           <label for="showLabels">Show Labels</label>
 
           <div>
-            <input @change="createURLFromCheckbox" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
+            <input @change="createURLFromChange" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
             <label for="showTrendLine">Show
               <input type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
                Day Doubling Time</label>
@@ -150,7 +150,7 @@
 
           <ul>
             <li v-for="country in visibleCountries">
-              <input @change="createURLFromCheckbox" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
+              <input @change="createURLFromChange" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
               <label :for="country">{{country}}</label>
             </li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -104,28 +104,28 @@
         <div>
           <h2>Customize</h2>
           <label for="selectedData">Select Parameter</label>
-          <select id="selectedData" v-model="selectedData" @mousedown="pause">
+          <select @change="createURLFromSelect" id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">
               {{ d }}
             </option>
           </select>
           <label for="selectedRegion">Select Region</label>
-          <select id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
+          <select @change="createURLFromSelect" id="selectedRegion" v-model="selectedRegion" @mousedown="pause">
             <option v-for="s in regions" v-bind:value="s">
               {{ s }}
             </option>
           </select>
           <label for="selectedScale">Select Scale</label>
-          <select id="selectedScale" v-model="selectedScale" @mousedown="pause">
+          <select @change="createURLFromSelect" id="selectedScale" v-model="selectedScale" @mousedown="pause">
             <option v-for="s in scale" v-bind:value="s">
               {{ s }}
             </option>
           </select>
-          <input type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
+          <input @change="createURLFromCheckbox" type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
           <label for="showLabels">Show Labels</label>
 
           <div>
-            <input type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
+            <input @change="createURLFromCheckbox" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
             <label for="showTrendLine">Show
               <input type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
                Day Doubling Time</label>
@@ -150,7 +150,7 @@
 
           <ul>
             <li v-for="country in visibleCountries">
-              <input @change="createURL" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
+              <input @change="createURLFromCheckbox" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
               <label :for="country">{{country}}</label>
             </li>
           </ul>

--- a/index.html
+++ b/index.html
@@ -127,7 +127,7 @@
           <div>
             <input @change="createURLFromChange" type="checkbox" style="margin-top: 0.75rem;" id="showTrendLine" v-model="showTrendLine">
             <label for="showTrendLine">Show
-              <input type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
+              <input @change="createURLFromChange" type="number" min="1" step="1" style="width: 3rem; padding: 0rem; font-size: inherit;" v-model.number="doublingTime" @focus="pause"  aria-label="Doubling Time in Days">
                Day Doubling Time</label>
           </div>
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -585,31 +585,6 @@ window.app = new Vue({
 
     },
 
-    // code to copy a string to the clipboard
-    // from https://hackernoon.com/copying-text-to-clipboard-with-javascript-df4d4988697f
-    copyToClipboard(str) {
-      const el = document.createElement('textarea');  // Create a <textarea> element
-      el.value = str;                                 // Set its value to the string that you want copied
-      el.setAttribute('readonly', '');                // Make it readonly to be tamper-proof
-      el.style.position = 'absolute';
-      el.style.left = '-9999px';                      // Move outside the screen to make it invisible
-      document.body.appendChild(el);                  // Append the <textarea> element to the HTML document
-      const selected =
-        document.getSelection().rangeCount > 0        // Check if there is any content selected previously
-          ? document.getSelection().getRangeAt(0)     // Store selection if found
-          : false;                                    // Mark as false to know no selection existed before
-      el.select();                                    // Select the <textarea> content
-      document.execCommand('copy');                   // Copy - only works as a result of a user action (e.g. click events)
-      document.body.removeChild(el);                  // Remove the <textarea> element
-      if (selected) {                                 // If a selection existed before copying
-        document.getSelection().removeAllRanges();    // Unselect everything on the HTML document
-        document.getSelection().addRange(selected);   // Restore the original selection
-      }
-
-      this.copied = true;
-      setTimeout(() => this.copied = false, 2500);
-    },
-
     // reference line for exponential growth with a given doubling time
     referenceLine(x) {
       return x * (1 - Math.pow(2, -this.lookbackTime / this.doublingTime));
@@ -932,8 +907,6 @@ window.app = new Vue({
     searchField: '',
 
     autoplay: true,
-
-    copied: false,
 
     firstLoad: true,
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -214,7 +214,8 @@ window.app = new Vue({
       if (urlParameters.has('trendline')) {
         let showTrendLine = urlParameters.get('trendline');
         this.showTrendLine = (showTrendLine == 'true');
-      } else if (urlParameters.has('doublingtime')) {
+      }      
+      if (urlParameters.has('doublingtime')) {
         let doublingTime = urlParameters.get('doublingtime');
         this.doublingTime = doublingTime;
       }
@@ -589,7 +590,8 @@ window.app = new Vue({
             
       if (!this.showTrendLine) {
         queryUrl.append('trendline', this.showTrendLine);
-      } else if (this.doublingTime != 2) {
+      }
+      if (this.doublingTime != 2) {
         queryUrl.append('doublingtime', this.doublingTime);
       }
       

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -540,7 +540,15 @@ window.app = new Vue({
       this.isHidden = !this.isHidden;
     },
 
-    createURL() {
+    createURLFromCheckbox() {
+      return createURL(true);
+    },
+    
+    createURLFromSelect() {
+      return createURL(false);
+    },
+    
+    createURL(checkbox) {
 
       let baseUrl = window.location.href.split('?')[0];
 
@@ -562,13 +570,17 @@ window.app = new Vue({
       let renames = {
         'China (Mainland)': 'China'
       };
-
-      for (let country of this.countries) {
-        if (this.selectedCountries.includes(country)) {
-          if (Object.keys(renames).includes(country)) {
-            queryUrl.append('location', renames[country]);
-          } else {
-            queryUrl.append('location', country);
+      
+      // only list all countries if a checkbox was changed
+      // this does not solve edgecases (default countries but changed labels/line) nor detect if the defaults were reached
+      if (checkbox) {
+        for (let country of this.countries) {
+          if (this.selectedCountries.includes(country)) {
+            if (Object.keys(renames).includes(country)) {
+              queryUrl.append('location', renames[country]);
+            } else {
+              queryUrl.append('location', country);
+            }
           }
         }
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -214,8 +214,7 @@ window.app = new Vue({
       if (urlParameters.has('trendline')) {
         let showTrendLine = urlParameters.get('trendline');
         this.showTrendLine = (showTrendLine == 'true');
-      }      
-      if (urlParameters.has('doublingtime')) {
+      } else if (urlParameters.has('doublingtime')) {
         let doublingTime = urlParameters.get('doublingtime');
         this.doublingTime = doublingTime;
       }
@@ -590,8 +589,7 @@ window.app = new Vue({
             
       if (!this.showTrendLine) {
         queryUrl.append('trendline', this.showTrendLine);
-      }
-      if (this.doublingTime != 2) {
+      } else if (this.doublingTime != 2) {
         queryUrl.append('doublingtime', this.doublingTime);
       }
       

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -218,6 +218,10 @@ window.app = new Vue({
         let doublingTime = urlParameters.get('doublingtime');
         this.doublingTime = doublingTime;
       }
+      
+      if (urlParameters.has('select')) {
+      this.mySelect = urlParameters.get('select').toLowerCase();
+      }
 
     }
 
@@ -447,7 +451,16 @@ window.app = new Vue({
       // but do not overwrite selected locations if 1. selected locations loaded from URL. 2. We switch between confirmed cases <-> deaths
       if ((this.selectedCountries.length === 0 || !this.firstLoad) && updateSelectedCountries) {
         this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
+        
         this.defaultCountries = this.selectedCountries // Used for createURL default check
+        
+        if (this.mySelect == 'all') {
+        this.selectedCountries = this.countries;
+        } else if (this.mySelect == 'none') {
+        this.selectedCountries = [];
+        }
+        this.mySelect = '';
+      
       }
 
       this.firstLoad = false;

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -594,7 +594,7 @@ window.app = new Vue({
       
       // check if the list of countries is identical to the current default
       if (this.selectedCountries.length === this.defaultCountries.length) {
-        defaultTag = true;
+        let defaultTag = true;
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
             if (!this.defaultCountries.includes(country)) {
@@ -604,7 +604,7 @@ window.app = new Vue({
           }
         }
       } else {
-        defaultTag = false;
+        let defaultTag = false;
       }
 
       // only list all countries if a checkbox was changed and if the list of countries isn't in default

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -596,7 +596,6 @@ window.app = new Vue({
         return;
       }
       
-      
       // check if the list of countries is identical to the current default
       let defaultTag;
       if (this.selectedCountries.length === this.defaultCountries.length) {
@@ -613,7 +612,7 @@ window.app = new Vue({
         defaultTag = false;
       }
 
-      // only list all countries if a checkbox was changed and if the list of countries isn't in default
+      // only list all countries if the list of countries isn't in default
       if (!defaultTag) {
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
@@ -626,7 +625,11 @@ window.app = new Vue({
         }
       }
       
-      window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+      if (queryUrl.toString() === "") {
+        window.history.replaceState({}, 'Covid Trends', location.pathname);
+      } else {
+        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+      }
 
     },
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -586,12 +586,28 @@ window.app = new Vue({
       
       // check if the list of countries has all or none of the countries
       // if all or none of the countries have been selected, then the later checks don't need to be done
-      if (this.selectedCountries.length === this.countries.length) {
-        queryUrl.append('select', 'all');
+      let noneTag = true;
+      for (let country of this.countries) {
+        if (this.selectedCountries.includes(country)) {
+          noneTag = false;
+          break;
+        }
+      }
+      if (noneTag) {
+        queryUrl.append('select', 'none');
         window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
         return;
-      } else if (this.selectedCountries.length === 0) {
-        queryUrl.append('select', 'none');
+      }
+      
+      let allTag = true;
+      for (let country of this.countries) {
+        if (!this.selectedCountries.includes(country)) {
+          allTag = false;
+          break;
+        }
+      }
+      if (allTag) {
+        queryUrl.append('select', 'all');
         window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
         return;
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -541,11 +541,11 @@ window.app = new Vue({
     },
 
     createURLFromCheckbox() {
-      return createURL(true);
+      this.createURL(true);
     },
     
     createURLFromSelect() {
-      return createURL(false);
+      this.createURL(false);
     },
     
     createURL(checkbox) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -593,8 +593,9 @@ window.app = new Vue({
       }
       
       // check if the list of countries is identical to the current default
+      let defaultTag;
       if (this.selectedCountries.length === this.defaultCountries.length) {
-        let defaultTag = true;
+        defaultTag = true;
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
             if (!this.defaultCountries.includes(country)) {
@@ -604,7 +605,7 @@ window.app = new Vue({
           }
         }
       } else {
-        let defaultTag = false;
+        defaultTag = false;
       }
 
       // only list all countries if a checkbox was changed and if the list of countries isn't in default

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -464,6 +464,7 @@ window.app = new Vue({
       }
 
       this.firstLoad = false;
+      this.createURLFromChange();
     },
 
     preprocessNYTData(data, type) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -531,12 +531,12 @@ window.app = new Vue({
 
     selectAll() {
       this.selectedCountries = this.countries;
-      this.createURL(false);
+      this.createURL(true);
     },
 
     deselectAll() {
       this.selectedCountries = [];
-      this.createURL(false);
+      this.createURL(true);
     },
 
     toggleHide() {
@@ -582,16 +582,18 @@ window.app = new Vue({
       
       // check if the list of countries has all or none of the countries
       // if all or none of the countries have been selected, then the later checks don't need to be done
-      if (this.selectedCountries.length === this.countries.length) {
-        queryUrl.append('select', 'all');
-        let url = baseUrl + '?' + queryUrl.toString();
-        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
-        return;
-      } else if (this.selectedCountries.length === 0) {
-        queryUrl.append('select', 'none');
-        let url = baseUrl + '?' + queryUrl.toString();
-        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
-        return;
+      if (checkbox) {
+        if (this.selectedCountries.length === this.countries.length) {
+          queryUrl.append('select', 'all');
+          let url = baseUrl + '?' + queryUrl.toString();
+          window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+          return;
+        } else if (this.selectedCountries.length === 0) {
+          queryUrl.append('select', 'none');
+          let url = baseUrl + '?' + queryUrl.toString();
+          window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+          return;
+        }
       }
       
       // check if the list of countries is identical to the current default

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -573,8 +573,16 @@ window.app = new Vue({
       };
       
       // check if the list of countries is identical to the current default
-      if (this.selectedCountries === this.defaultCountries) {
+      if (this.selectedCountries.length === this.defaultCountries.length) {
         defaultTag = true;
+        for (let country of this.countries) {
+          if (this.selectedCountries.includes(country)) {
+            if (!this.defaultCountries.includes(country)) {
+              defaultTag = false;
+              break;
+            }
+          }
+        }
       } else {
         defaultTag = false;
       }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -464,7 +464,7 @@ window.app = new Vue({
       }
 
       this.firstLoad = false;
-      this.createURLFromChange();
+      this.createURL();
     },
 
     preprocessNYTData(data, type) {
@@ -545,27 +545,19 @@ window.app = new Vue({
 
     selectAll() {
       this.selectedCountries = this.countries;
-      this.createURL(true);
+      this.createURL();
     },
 
     deselectAll() {
       this.selectedCountries = [];
-      this.createURL(true);
+      this.createURL();
     },
 
     toggleHide() {
       this.isHidden = !this.isHidden;
     },
-
-    createURLFromChange() {
-      this.createURL(true);
-    },
     
-    createURLFromRegion() {
-      this.createURL(false);
-    },
-    
-    createURL(change) {
+    createURL() {
 
       let baseUrl = window.location.href.split('?')[0];
 
@@ -596,19 +588,18 @@ window.app = new Vue({
       
       // check if the list of countries has all or none of the countries
       // if all or none of the countries have been selected, then the later checks don't need to be done
-      if (change) {
-        if (this.selectedCountries.length === this.countries.length) {
-          queryUrl.append('select', 'all');
-          let url = baseUrl + '?' + queryUrl.toString();
-          window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
-          return;
-        } else if (this.selectedCountries.length === 0) {
-          queryUrl.append('select', 'none');
-          let url = baseUrl + '?' + queryUrl.toString();
-          window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
-          return;
-        }
+      if (this.selectedCountries.length === this.countries.length) {
+        queryUrl.append('select', 'all');
+        let url = baseUrl + '?' + queryUrl.toString();
+        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+        return;
+      } else if (this.selectedCountries.length === 0) {
+        queryUrl.append('select', 'none');
+        let url = baseUrl + '?' + queryUrl.toString();
+        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+        return;
       }
+      
       
       // check if the list of countries is identical to the current default
       let defaultTag;
@@ -627,7 +618,7 @@ window.app = new Vue({
       }
 
       // only list all countries if a checkbox was changed and if the list of countries isn't in default
-      if (change && !defaultTag) {
+      if (!defaultTag) {
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
             if (Object.keys(renames).includes(country)) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -573,16 +573,12 @@ window.app = new Vue({
       };
       
       // check if the list of countries is identical to the current default
-      defaultTag = true;
-      for (let country of this.countries) {
-        if (this.selectedCountries.includes(country)) {
-          if (!this.defaultCountries.includes(country)) {
-            defaultTag = false;
-            break;
-          }
-        }
+      if (this.selectedCountries === this.defaultCountries) {
+        defaultTag = true;
+      } else {
+        defaultTag = false;
       }
-      
+
       // only list all countries if a checkbox was changed and if the list of countries isn't in default
       if (checkbox && !defaultTag) {
         for (let country of this.countries) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -556,15 +556,15 @@ window.app = new Vue({
       this.isHidden = !this.isHidden;
     },
 
-    createURLFromCheckbox() {
+    createURLFromChange() {
       this.createURL(true);
     },
     
-    createURLFromSelect() {
+    createURLFromRegion() {
       this.createURL(false);
     },
     
-    createURL(checkbox) {
+    createURL(change) {
 
       let baseUrl = window.location.href.split('?')[0];
 
@@ -595,7 +595,7 @@ window.app = new Vue({
       
       // check if the list of countries has all or none of the countries
       // if all or none of the countries have been selected, then the later checks don't need to be done
-      if (checkbox) {
+      if (change) {
         if (this.selectedCountries.length === this.countries.length) {
           queryUrl.append('select', 'all');
           let url = baseUrl + '?' + queryUrl.toString();
@@ -626,7 +626,7 @@ window.app = new Vue({
       }
 
       // only list all countries if a checkbox was changed and if the list of countries isn't in default
-      if (checkbox && !defaultTag) {
+      if (change && !defaultTag) {
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
             if (Object.keys(renames).includes(country)) {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -583,8 +583,6 @@ window.app = new Vue({
 
       window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
 
-      this.copyToClipboard(url);
-
     },
 
     // code to copy a string to the clipboard

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -571,6 +571,26 @@ window.app = new Vue({
       let renames = {
         'China (Mainland)': 'China'
       };
+            
+      if (!this.showTrendLine) {
+        queryUrl.append('trendline', this.showTrendLine);
+      } else if (this.doublingTime != 2) {
+        queryUrl.append('doublingtime', this.doublingTime);
+      }
+      
+      // check if the list of countries has all or none of the countries
+      // if all or none of the countries have been selected, then the later checks don't need to be done
+      if (this.selectedCountries.length === this.countries.length) {
+        queryUrl.append('select', 'all');
+        let url = baseUrl + '?' + queryUrl.toString();
+        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+        return;
+      } else if (this.selectedCountries.length === 0) {
+        queryUrl.append('select', 'none');
+        let url = baseUrl + '?' + queryUrl.toString();
+        window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
+        return;
+      }
       
       // check if the list of countries is identical to the current default
       if (this.selectedCountries.length === this.defaultCountries.length) {
@@ -599,13 +619,7 @@ window.app = new Vue({
           }
         }
       }
-
-      if (!this.showTrendLine) {
-        queryUrl.append('trendline', this.showTrendLine);
-      } else if (this.doublingTime != 2) {
-        queryUrl.append('doublingtime', this.doublingTime);
-      }
-
+      
       let url = baseUrl + '?' + queryUrl.toString();
 
       window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -558,9 +558,7 @@ window.app = new Vue({
     },
     
     createURL() {
-
-      let baseUrl = window.location.href.split('?')[0];
-
+      
       let queryUrl = new URLSearchParams();
 
       if (this.selectedScale == 'Linear Scale') {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -531,10 +531,12 @@ window.app = new Vue({
 
     selectAll() {
       this.selectedCountries = this.countries;
+      this.createURL(false);
     },
 
     deselectAll() {
       this.selectedCountries = [];
+      this.createURL(false);
     },
 
     toggleHide() {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -447,6 +447,7 @@ window.app = new Vue({
       // but do not overwrite selected locations if 1. selected locations loaded from URL. 2. We switch between confirmed cases <-> deaths
       if ((this.selectedCountries.length === 0 || !this.firstLoad) && updateSelectedCountries) {
         this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
+        this.defaultCountries = this.selectedCountries // Used for createURL default check
       }
 
       this.firstLoad = false;
@@ -571,9 +572,19 @@ window.app = new Vue({
         'China (Mainland)': 'China'
       };
       
-      // only list all countries if a checkbox was changed
-      // this does not solve edgecases (default countries but changed labels/line) nor detect if the defaults were reached
-      if (checkbox) {
+      // check if the list of countries is identical to the current default
+      defaultTag = true;
+      for (let country of this.countries) {
+        if (this.selectedCountries.includes(country)) {
+          if (!this.defaultCountries.includes(country)) {
+            defaultTag = false;
+            break;
+          }
+        }
+      }
+      
+      // only list all countries if a checkbox was changed and if the list of countries isn't in default
+      if (checkbox && !defaultTag) {
         for (let country of this.countries) {
           if (this.selectedCountries.includes(country)) {
             if (Object.keys(renames).includes(country)) {
@@ -915,6 +926,8 @@ window.app = new Vue({
     doublingTime: 2,
 
     selectedCountries: [],
+    
+    defaultCountries: [], // Used for createURL default check
 
     searchField: '',
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -220,7 +220,7 @@ window.app = new Vue({
       }
       
       if (urlParameters.has('select')) {
-      this.mySelect = urlParameters.get('select').toLowerCase();
+        this.mySelect = urlParameters.get('select').toLowerCase();
       }
 
     }
@@ -452,12 +452,12 @@ window.app = new Vue({
       if ((this.selectedCountries.length === 0 || !this.firstLoad) && updateSelectedCountries) {
         this.selectedCountries = this.countries.filter(e => topCountries.includes(e) || notableCountries.includes(e));
         
-        this.defaultCountries = this.selectedCountries // Used for createURL default check
+        this.defaultCountries = this.selectedCountries; // Used for createURL default check
         
         if (this.mySelect == 'all') {
-        this.selectedCountries = this.countries;
+          this.selectedCountries = this.countries;
         } else if (this.mySelect == 'none') {
-        this.selectedCountries = [];
+          this.selectedCountries = [];
         }
         this.mySelect = '';
       
@@ -590,12 +590,10 @@ window.app = new Vue({
       // if all or none of the countries have been selected, then the later checks don't need to be done
       if (this.selectedCountries.length === this.countries.length) {
         queryUrl.append('select', 'all');
-        let url = baseUrl + '?' + queryUrl.toString();
         window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
         return;
       } else if (this.selectedCountries.length === 0) {
         queryUrl.append('select', 'none');
-        let url = baseUrl + '?' + queryUrl.toString();
         window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
         return;
       }
@@ -630,8 +628,6 @@ window.app = new Vue({
         }
       }
       
-      let url = baseUrl + '?' + queryUrl.toString();
-
       window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());
 
     },

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -625,7 +625,7 @@ window.app = new Vue({
         }
       }
       
-      if (queryUrl.toString() === "") {
+      if (queryUrl.toString() === '') {
         window.history.replaceState({}, 'Covid Trends', location.pathname);
       } else {
         window.history.replaceState({}, 'Covid Trends', '?' + queryUrl.toString());

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -964,6 +964,8 @@ window.app = new Vue({
     selectedCountries: [],
     
     defaultCountries: [], // Used for createURL default check
+    
+    mySelect: '',
 
     searchField: '',
 


### PR DESCRIPTION
Proposed solution for #163.

The submitted code does some things:
- Removes the Create Shareable Link button.
- Automatically updates the URL address whenever a country/location button is pressed, whenever the parameter/region/scale is changed and whenever the trending line is changed (disabled or value changed)
- Whenever the page displays default values, the address bar doesn't clog up with all the countries and omits them until someone presses more countries.
- Whenever someone selects all or none countries, the same logic above applies, and a new parameter, `select`, is used.

I've tested the code locally (using the simple Python server) and everything seems to work properly, although any sort of code review is very welcome (as I'm still a bit new to JS).

~~There is an odd case whenever someone selects all countries and then changes to Reported Deaths, instead of showing the simplified parameter, the URL bar does clog up a little. The end result is the same.~~(Fixed)

Feedback is welcome.