### PR TITLE
Regional data for Brazil

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -476,11 +476,40 @@ window.app = new Vue({
 
     preprocessBrasilIOData(data, type) {
       let recastData = {};
+      let states = {
+        'AC': 'Acre',
+        'AL': 'Alagoas',
+        'AP': 'Amapá',
+        'AM': 'Amazonas',
+        'BA': 'Bahia',
+        'CE': 'Ceará',
+        'DF': 'Distrito Federal',
+        'ES': 'Espírito Santo',
+        'GO': 'Goiás',
+        'MA': 'Maranhão',
+        'MT': 'Mato Grosso',
+        'MS': 'Mato Grosso do Sul',
+        'MG': 'Minas Gerais',
+        'PA': 'Pará',
+        'PB': 'Paraíba',
+        'PR': 'Paraná',
+        'PE': 'Pernambuco',
+        'PI': 'Piauí',
+        'RJ': 'Rio de Janeiro',
+        'RN': 'Rio Grande do Norte',
+        'RS': 'Rio Grande do Sul',
+        'RO': 'Rondônia',
+        'RR': 'Roraima',
+        'SC': 'Santa Catarina',
+        'SP': 'São Paulo',
+        'SE': 'Sergipe',
+        'TO': 'Tocantins'
+      };
       data.reverse().forEach(e => {
         // the Brasil.io dataset lists every city with reported cases
         // to aggregate data for an entire state, there's always a null city
         if (e.place_type == 'state') {
-          let st = recastData[e.state] = (recastData[e.state] || {'Province/State': e.state, 'Country/Region': 'Brazil', 'Lat': null, 'Long': null});
+          let st = recastData[states[e.state]] = (recastData[states[e.state]] || {'Province/State': states[e.state], 'Country/Region': 'Brazil', 'Lat': null, 'Long': null});
           st[fixBrasilIODate(e.date)] = parseInt(e[type]); 
         }
       });

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -338,7 +338,7 @@ window.app = new Vue({
         }
         if (selectedRegion == 'Brazil') {
           const type = (selectedData == 'Reported Deaths') ? 'last_available_deaths' : 'last_available_confirmed';
-          const url = 'https://brasil.io/dataset/covid19/caso_full/?format=csv';
+          const url = 'https://brasil.io/dataset/covid19/caso_full/?place_type=state&format=csv';
           Plotly.d3.csv(url, (data) => this.processData(this.preprocessBrasilIOData(data, type), selectedRegion, updateSelectedCountries));
         }
       }
@@ -506,12 +506,8 @@ window.app = new Vue({
         'TO': 'Tocantins'
       };
       data.reverse().forEach(e => {
-        // the Brasil.io dataset lists every city with reported cases
-        // to aggregate data for an entire state, there's always a null city
-        if (e.place_type == 'state') {
-          let st = recastData[states[e.state]] = (recastData[states[e.state]] || {'Province/State': states[e.state], 'Country/Region': 'Brazil', 'Lat': null, 'Long': null});
-          st[fixBrasilIODate(e.date)] = parseInt(e[type]); 
-        }
+        let st = recastData[states[e.state]] = (recastData[states[e.state]] || {'Province/State': states[e.state], 'Country/Region': 'Brazil', 'Lat': null, 'Long': null});
+        st[fixBrasilIODate(e.date)] = parseInt(e[type]); 
       });
       return Object.values(recastData);
       

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -476,7 +476,7 @@ window.app = new Vue({
 
     preprocessBrasilIOData(data, type) {
       let recastData = {};
-      data.reverse().forEach(e =>{
+      data.reverse().forEach(e => {
         // the Brasil.io dataset lists every city with reported cases
         // to aggregate data for an entire state, there's always a null city
         if (e.place_type == 'state') {


### PR DESCRIPTION
I have used data from Brasil.io, which is a volunteer-task force that gathers from government authorities (city halls, state governments and federal government) and present them in more friendly formats than the official government websites. They update their database daily. More info (in PT-BR) is available here:
https://brasil.io/covid19/
The CSV link I used, which is updated daily, is here:
https://brasil.io/dataset/covid19/caso_full/?format=csv

They also have a JSON API and a GitHub repository: https://github.com/turicas/covid19-br