### PR TITLE
Hovertemplate breaks

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -716,9 +716,9 @@ window.app = new Vue({
 
       let showDailyMarkers = this.filteredCovidData.length <= 2;
 
-      let weeklyTotalExtra =
-        '<br>%{y:8,}: Weekly ' + this.selectedData +
-        '<br>%{x:8,}: Total ' + this.selectedData +
+      let hovertemplateBody =
+        '<br>%{y:10,}: Weekly ' + this.selectedData +
+        '<br>%{x:10,}: Total ' + this.selectedData +
         '<extra></extra>';
 
       // draws grey lines (line plot for each location)
@@ -738,7 +738,7 @@ window.app = new Vue({
           color: 'rgba(0,0,0,0.15)'
         },
         hoverinfo: 'x+y+text',
-        hovertemplate: '%{text}' + weeklyTotalExtra,
+        hovertemplate: '%{text}' + hovertemplateBody,
       })
       );
 
@@ -755,7 +755,7 @@ window.app = new Vue({
           size: 6,
           color: 'rgba(254, 52, 110, 1)'
         },
-        hovertemplate: '%{data.text}' +  weeklyTotalExtra,
+        hovertemplate: '%{data.text}' +  hovertemplateBody,
 
       }));
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -755,7 +755,7 @@ window.app = new Vue({
           size: 6,
           color: 'rgba(254, 52, 110, 1)'
         },
-        hovertemplate: '%{data.text}' +  hovertemplateBody,
+        hovertemplate: '%{data.text}' + hovertemplateBody,
 
       }));
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -733,7 +733,11 @@ window.app = new Vue({
           color: 'rgba(0,0,0,0.15)'
         },
         hoverinfo: 'x+y+text',
-        hovertemplate: '%{text}<br>Total ' + this.selectedData + ': %{x:,}<br>Weekly ' + this.selectedData + ': %{y:,}<extra></extra>',
+        hovertemplate:
+          '%{text}' +
+          '<br>Total ' + this.selectedData + ': %{x:,}' +
+          '<br>Weekly ' + this.selectedData + ': %{y:,}' +
+          '<extra></extra>',
       })
       );
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -735,8 +735,8 @@ window.app = new Vue({
         hoverinfo: 'x+y+text',
         hovertemplate:
           '%{text}' +
-          '<br>Total ' + this.selectedData + ': %{x:,}' +
           '<br>Weekly ' + this.selectedData + ': %{y:,}' +
+          '<br>Total ' + this.selectedData + ': %{x:,}' +
           '<extra></extra>',
       })
       );

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -716,6 +716,11 @@ window.app = new Vue({
 
       let showDailyMarkers = this.filteredCovidData.length <= 2;
 
+      let weeklyTotalExtra =
+        '<br>%{y:8,}: Weekly ' + this.selectedData +
+        '<br>%{x:8,}: Total ' + this.selectedData +
+        '<extra></extra>';
+
       // draws grey lines (line plot for each location)
       let trace1 = this.filteredCovidData.map((e, i) => ({
         x: e.cases.slice(0, this.day),
@@ -733,11 +738,7 @@ window.app = new Vue({
           color: 'rgba(0,0,0,0.15)'
         },
         hoverinfo: 'x+y+text',
-        hovertemplate:
-          '%{text}' +
-          '<br>Weekly ' + this.selectedData + ': %{y:,}' +
-          '<br>Total ' + this.selectedData + ': %{x:,}' +
-          '<extra></extra>',
+        hovertemplate: '%{text}' + weeklyTotalExtra,
       })
       );
 
@@ -754,7 +755,7 @@ window.app = new Vue({
           size: 6,
           color: 'rgba(254, 52, 110, 1)'
         },
-        hovertemplate: '%{data.text}<br>Total ' + this.selectedData + ': %{x:,}<br>Weekly ' + this.selectedData + ': %{y:,}<extra></extra>',
+        hovertemplate: '%{data.text}' +  weeklyTotalExtra,
 
       }));
 


### PR DESCRIPTION
Update hovertemplate to  read better: numbers on left, more or less aligned in a column.

It's not perfect because the font being used doesn't have consistent width for digits comma and space.

Small error in a commit, doesn't matter in the end:
File was unsaved in VS code, so the commit at 666b7d9 wasn't quite the latest version. 
So the commit message is "future", prophesying the name change in the next commit 937f9c0.
By the way:
The reason I changed the name was to avoid getting too concrete. 
The name weeklyTotalExtra expresses the contents too much. If it was total, weekly, extra, then I would not want to change the name. So "hovertemplateBody" says that this is used in the hovertemplate:, but not exactly what is in it and what order.