### PR TITLE
Use array this.traceIndices directly in Plotly.restyle(), avoiding fo…

### DIFF
--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -27,21 +27,17 @@ Vue.component('graph', {
         this.traceIndices = this.graphData.traces.map((e, i) => e.name == name ? i : -1).filter(e => e >= 0);
         let update = {'line': {color: 'rgba(254, 52, 110, 1)'}};
 
-        for (let i of this.traceIndices) {
-          Plotly.restyle(this.$refs.graph, update, [i]);
-        }
+        Plotly.restyle(this.$refs.graph, update, this.traceIndices);
       }
 
     },
 
-    onHoverOff() {
+    onHoverOff(_) {
 
       let update = {'line': {color: 'rgba(0,0,0,0.15)'}};
 
-      for (let i of this.traceIndices) {
-        Plotly.restyle(this.$refs.graph, update, [i]);
-      }
-
+      Plotly.restyle(this.$refs.graph, update, this.traceIndices);
+      
     },
 
     onLayoutChange(data) {


### PR DESCRIPTION
Avoid for loop overhead by passing this.traceIndices to Plotly.restyle

There is no need to send each index separately as [i]. Let Plotly do the work.