### PR TITLE
Move scroll bar to country list

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@
 
           <p style="padding-top: 1rem;">Showing {{regionType}} with at least {{minCasesInCountry}} {{selectedData}}</p>
 
-          <ul>
+          <ul class="country-list">
             <li v-for="country in visibleCountries">
               <input @change="createURL" type="checkbox" :id="country" :value="country" v-model="selectedCountries">
               <label :for="country">{{country}}</label>

--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
 
         <div v-if="!firstLoad && covidData.length == 0" class="nodata"><span>Not enough data for these parameters.</span></div>
         <div v-if="!firstLoad && covidData.length != 0 && !countries.some(country => selectedCountries.includes(country))" class="nodata"><span>Please select some {{regionType.toLowerCase()}} to display.</span></div>
-        
+
         <footer>
           Created by <a href="https://aatishb.com/">Aatish Bhatia</a> in collaboration with <a href="https://www.youtube.com/user/minutephysics">Minute Physics</a> &middot; World data provided by <a href="https://github.com/CSSEGISandData/COVID-19">Johns Hopkins University</a> (updated daily around 00:00 UTC / 20:00 ET) &middot; US state data provided by <a href="https://github.com/nytimes/covid-19-data">NYTimes</a> (updated daily around 16:00 UTC / 12:00 ET)&middot; Shortcuts: +/- for daily changes, space to play/pause &middot; <a href="https://github.com/aatishb/covidtrends#credits">Credits & Source</a> &middot; <a href="https://www.cdc.gov/coronavirus/2019-ncov/prepare/prevention.html">Stay safe!</a>
         </footer>
@@ -102,7 +102,7 @@
 
       <aside>
 
-        <div>
+        <div class="customize">
           <h2>Customize</h2>
           <label for="selectedData">Select Parameter</label>
           <select id="selectedData" v-model="selectedData" @mousedown="pause">

--- a/style.css
+++ b/style.css
@@ -160,12 +160,8 @@ aside {
   -webkit-overflow-scrolling: touch;
 }
 
-aside > div {
+.customize {
   margin-bottom: 2rem;
-}
-
-aside > div:last-child {
-  margin-bottom: 0;
 }
 
 .countries {

--- a/style.css
+++ b/style.css
@@ -156,7 +156,7 @@ aside {
   padding: 1rem;
   min-width: 10rem;
 
-  overflow-y: auto;
+  overflow-y: hidden;
   -webkit-overflow-scrolling: touch;
 }
 
@@ -165,7 +165,13 @@ aside {
 }
 
 .countries {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow-y: hidden;
+}
 
+.country-list {
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }


### PR DESCRIPTION
Currently at high zoom, the country list on the page can disappear, confusing users. 

This is an attempt to fix this by moving the scroll bar to the country list, rather than scrolling the entire country section.