### PR TITLE
Alternative to country list scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,9 +101,10 @@
       </main>
 
       <aside>
-
-        <div>
+        <div class="customizetopwrapper">
           <h2>Customize</h2>
+        </div>
+        <div>
           <label for="selectedData">Select Parameter</label>
           <select id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">
@@ -133,6 +134,8 @@
           </div>
 
         </div>
+
+        <div class="separator"></div>
 
         <div class="countries">
 

--- a/index.html
+++ b/index.html
@@ -136,18 +136,22 @@
 
         <div class="countries">
 
-          <h2>{{regionType}}</h2>
+          <div class="countriestopwrapper">
 
-          <div class="search">
-            <input id="searchField" v-model="searchField" placeholder="Search For A Location" aria-label="Search For A Location">
+            <h2>{{regionType}}</h2>
+
+            <div class="search">
+              <input id="searchField" v-model="searchField" placeholder="Search For A Location" aria-label="Search For A Location">
+            </div>
+
+            <div class="buttonwrapper">
+              <button @click="deselectAll" aria-Label="Deselect All Regions">Deselect All</button>
+              <button @click="selectAll" aria-Label="Select All Regions">Select All</button>
+            </div>
+
+            <p style="padding-top: 1rem;">Showing {{regionType}} with at least {{minCasesInCountry}} {{selectedData}}</p>
+
           </div>
-
-          <div class="buttonwrapper">
-            <button @click="deselectAll" aria-Label="Deselect All Regions">Deselect All</button>
-            <button @click="selectAll" aria-Label="Select All Regions">Select All</button>
-          </div>
-
-          <p style="padding-top: 1rem;">Showing {{regionType}} with at least {{minCasesInCountry}} {{selectedData}}</p>
 
           <ul>
             <li v-for="country in visibleCountries">

--- a/index.html
+++ b/index.html
@@ -104,7 +104,7 @@
         <div class="customizetopwrapper">
           <h2 @click="scrollToCustomize">Customize</h2>
         </div>
-        <div>
+        <div class="customize">
           <label for="selectedData">Select Parameter</label>
           <select id="selectedData" v-model="selectedData" @mousedown="pause">
             <option v-for="d in dataTypes" v-bind:value="d">

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
 
       <aside>
         <div class="customizetopwrapper">
-          <h2>Customize</h2>
+          <h2 @click="scrollToCustomize">Customize</h2>
         </div>
         <div>
           <label for="selectedData">Select Parameter</label>
@@ -141,7 +141,7 @@
 
           <div class="countriestopwrapper">
 
-            <h2>{{regionType}}</h2>
+            <h2 @click="scrollToCountries">{{regionType}}</h2>
 
             <div class="search">
               <input id="searchField" v-model="searchField" placeholder="Search For A Location" aria-label="Search For A Location">

--- a/style.css
+++ b/style.css
@@ -172,6 +172,12 @@ aside > div:last-child {
 aside h2 {
   font-size: 1.5rem;
   text-align: center;
+  
+  transition-duration: 0.4s;
+}
+
+aside h2:hover {
+  color: #FF4C00;
 }
 
 .customizetopwrapper {
@@ -184,17 +190,21 @@ aside h2 {
   background-color: #fcf8e8;
 }
 
+.customize {
+  margin-bottom: 1rem;
+}
+
 .separator {
   position: -webkit-sticky;
   position: sticky;
   top: 3.5rem;
-  border: 0.1rem solid #333;
+  border: 1px solid #333;
 }
 
 .countriestopwrapper {
   position: -webkit-sticky;
   position: sticky;
-  top: 3.6rem; /* Enough to fit the element before (3.5rem) and a separator */
+  top: calc(3.5rem + 2px); /* Enough to fit the element before (3.5rem) and a separator */
   padding-top: 1rem;
   padding-bottom: 0.75rem;
 

--- a/style.css
+++ b/style.css
@@ -154,6 +154,7 @@ aside {
 
   background-color: #fcf8e8;
   padding: 1rem;
+  padding-top: 0; /* Letting customizetopwrapper take care of this */
   min-width: 10rem;
 
   overflow-y: auto;
@@ -173,12 +174,27 @@ aside h2 {
   text-align: center;
 }
 
+.customizetopwrapper {
+  margin: 0;
+
+  position: sticky;
+  top:  0; /* Same as aside padding-top */
+  padding-top: 1rem;
+  background-color: #fcf8e8;
+}
+
+.separator {
+  position: sticky;
+  top: 3.5rem;
+  border: 0.1rem solid #333;
+}
+
 .countriestopwrapper {
   position: sticky;
-  top: -1rem; /* Same as aside padding-top */
+  top: 3.6rem; /* Enough to fit the element before (3.5rem) and a separator */
   padding-top: 1rem;
   padding-bottom: 0.75rem;
-  
+
   background-color: #fcf8e8;
 }
 
@@ -227,7 +243,6 @@ svg {
   width: 100%;
   display: flex;
   flex-direction: row;
-  min-width: 10rem;
 }
 
 .search > input {
@@ -279,7 +294,6 @@ button:hover {
 }
 
 select {
-  min-width: 12rem;
   font-size: 1rem;
   padding: 0.5rem;
   width: 100%;

--- a/style.css
+++ b/style.css
@@ -168,13 +168,18 @@ aside > div:last-child {
   margin-bottom: 0;
 }
 
-.countries {
-  -webkit-overflow-scrolling: touch;
-}
-
 aside h2 {
   font-size: 1.5rem;
   text-align: center;
+}
+
+.countriestopwrapper {
+  position: sticky;
+  top: -1rem; /* Same as aside padding-top */
+  padding-top: 1rem;
+  padding-bottom: 0.75rem;
+  
+  background-color: #fcf8e8;
 }
 
 footer {
@@ -268,6 +273,9 @@ button:hover {
 }
 .countries p {
   margin-bottom: 0.75rem;
+}
+.countriestopwrapper p {
+  margin-bottom: 0;
 }
 
 select {

--- a/style.css
+++ b/style.css
@@ -177,6 +177,7 @@ aside h2 {
 .customizetopwrapper {
   margin: 0;
 
+  position: -webkit-sticky;
   position: sticky;
   top:  0; /* Same as aside padding-top */
   padding-top: 1rem;
@@ -184,12 +185,14 @@ aside h2 {
 }
 
 .separator {
+  position: -webkit-sticky;
   position: sticky;
   top: 3.5rem;
   border: 0.1rem solid #333;
 }
 
 .countriestopwrapper {
+  position: -webkit-sticky;
   position: sticky;
   top: 3.6rem; /* Enough to fit the element before (3.5rem) and a separator */
   padding-top: 1rem;

--- a/style.css
+++ b/style.css
@@ -169,8 +169,6 @@ aside > div:last-child {
 }
 
 .countries {
-
-  overflow-y: auto;
   -webkit-overflow-scrolling: touch;
 }
 

--- a/style.css
+++ b/style.css
@@ -199,6 +199,7 @@ aside h2:hover {
   position: sticky;
   top: 3.5rem;
   border: 1px solid #333;
+  margin: 0;
 }
 
 .countriestopwrapper {

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -630,7 +630,7 @@ window.app = new Vue({
     },
 
     scrollToCountries() {
-      const ctw = document.getElementsByClassName('customizetopwrapper')[0];
+      const ctw = document.getElementsByClassName('countriestopwrapper')[0];
       document.getElementsByClassName('countries')[0].scrollIntoView();
       document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)['top'])+1); // the +1 avoids a weird (fractional) scrolling issue
     }

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -621,6 +621,18 @@ window.app = new Vue({
     // reference line for exponential growth with a given doubling time
     referenceLine(x) {
       return x * (1 - Math.pow(2, -this.lookbackTime / this.doublingTime));
+    },
+    
+    scrollToCustomize() {
+      const ctw = document.getElementsByClassName("customizetopwrapper")[0];
+      document.getElementsByClassName('customize')[0].scrollIntoView();
+      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)["height"])-parseFloat(getComputedStyle(ctw)["padding-top"]));
+    },
+
+    scrollToCountries() {
+      const ctw = document.getElementsByClassName("customizetopwrapper")[0];
+      document.getElementsByClassName('countries')[0].scrollIntoView();
+      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)["height"])-parseFloat(getComputedStyle(ctw)["padding-top"]));
     }
 
   },

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -622,7 +622,7 @@ window.app = new Vue({
     referenceLine(x) {
       return x * (1 - Math.pow(2, -this.lookbackTime / this.doublingTime));
     },
-    
+
     scrollToCustomize() {
       const ctw = document.getElementsByClassName('customizetopwrapper')[0];
       document.getElementsByClassName('customize')[0].scrollIntoView();
@@ -632,7 +632,7 @@ window.app = new Vue({
     scrollToCountries() {
       const ctw = document.getElementsByClassName('customizetopwrapper')[0];
       document.getElementsByClassName('countries')[0].scrollIntoView();
-      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)['height'])-parseFloat(getComputedStyle(ctw)['padding-top']));
+      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)['top'])+1); // the +1 avoids a weird (fractional) scrolling issue
     }
 
   },

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -624,15 +624,15 @@ window.app = new Vue({
     },
     
     scrollToCustomize() {
-      const ctw = document.getElementsByClassName("customizetopwrapper")[0];
+      const ctw = document.getElementsByClassName('customizetopwrapper')[0];
       document.getElementsByClassName('customize')[0].scrollIntoView();
-      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)["height"])-parseFloat(getComputedStyle(ctw)["padding-top"]));
+      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)['height'])-parseFloat(getComputedStyle(ctw)['padding-top']));
     },
 
     scrollToCountries() {
-      const ctw = document.getElementsByClassName("customizetopwrapper")[0];
+      const ctw = document.getElementsByClassName('customizetopwrapper')[0];
       document.getElementsByClassName('countries')[0].scrollIntoView();
-      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)["height"])-parseFloat(getComputedStyle(ctw)["padding-top"]));
+      document.getElementsByTagName('aside')[0].scrollBy(0,-parseFloat(getComputedStyle(ctw)['height'])-parseFloat(getComputedStyle(ctw)['padding-top']));
     }
 
   },


### PR DESCRIPTION
So, this is an alternative to the way the right side of the page is being scrolled. I had thought of this some time ago, but just changing a single line didn't seem too big of an improvement, so I added a bit more functionality to make it worth it.
I'm creating the pull request mostly as a way to show what I thought of this and also as a way to check some bugs that might be lurking. I'm not saying this is the right or best way to do this, or even that there is a wrong way, just presenting different ways to do this.

So, this removes the scrollbar from the countries list, allowing for the right side to scroll. However, if you scroll to the bottom of the list, getting up might be an issue, so I tried to make the titles of the sections to always appear on top, and clicking on them would lead to the top of the sections.

The bugs I know of are two: There's a pixel-wide scrolling issue with the separator that I tried to fix, but it still shows up occasionally, and it might be browser dependent, as it's a drawing issue. The other one is due to keyboard scrolling with Tab, in which the section doesn't show the selected object.

Feedback and comments are always welcome.