### PR TITLE
Add playback speed selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,12 @@
               {{ s }}
             </option>
           </select>
+          <label for="selectedSpeed">Select Playback Speed</label>
+          <select @change="createURL" id="selectedSpeed" v-model="selectedSpeed" @mousedown="pause">
+            <option v-for="s in speeds" v-bind:value="s">
+              {{ s }}
+            </option>
+          </select>
           <input type="checkbox" style="margin-top: 0.75rem;" id="showLabels" v-model="showLabels">
           <label for="showLabels">Show Labels</label>
 

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -198,6 +198,13 @@ window.app = new Vue({
         }
       }
 
+      if (urlParameters.has('speed')) {
+        let mySpeed = urlParameters.get('speed');
+        if (this.speeds.includes(mySpeed)) {
+          this.selectedSpeed = mySpeed;
+        }
+      }
+
       // since this rename came later, use the old name to not break existing URLs
       let renames = {
         'China': 'China (Mainland)'
@@ -502,6 +509,25 @@ window.app = new Vue({
     },
 
     // TODO: clean up play/pause logic
+
+    getSpeed() {
+      switch (this.selectedSpeed) {
+        case 'Normal':
+          return 200;
+        case 'Slow':
+          return 500;
+        case 'Super Slow':
+          return 1000;
+        case 'Fast':
+          return 100;
+        case 'Super Fast':
+          return 50;
+        default:
+          return 200;
+      }
+
+    },
+
     play() {
       if (this.paused) {
 
@@ -510,7 +536,7 @@ window.app = new Vue({
         }
 
         this.paused = false;
-        setTimeout(this.increment, 200);
+        setTimeout(this.increment, this.getSpeed());
 
       } else {
         this.paused = true;
@@ -533,7 +559,7 @@ window.app = new Vue({
       else if (this.day < this.dates.length) {
         if (!this.paused) {
           this.day++;
-          setTimeout(this.increment, 200);
+          setTimeout(this.increment, this.getSpeed());
         }
       }
 
@@ -571,6 +597,10 @@ window.app = new Vue({
 
       if (this.selectedRegion != 'World') {
         queryUrl.append('region', this.selectedRegion);
+      }
+
+      if (this.selectedSpeed != 'Normal') {
+        queryUrl.append('speed', this.selectedSpeed);
       }
 
       // since this rename came later, use the old name for URLs to avoid breaking existing URLs
@@ -898,6 +928,10 @@ window.app = new Vue({
   data: {
 
     paused: true,
+
+    selectedSpeed: 'Normal',
+
+    speeds: ['Super Fast', 'Fast', 'Normal', 'Slow', 'Super Slow'],
 
     dataTypes: ['Confirmed Cases', 'Reported Deaths'],
 


### PR DESCRIPTION
I've been checking in with this graph occasionally ever since it was mentioned on the MinuteEarth video. Since it's going through a larger range of data as time goes on, some people (namely, me) would prefer to go through it a little quicker.

Then I realised I also wanted to go through it slower in the latest last 1/4 or 1/8 of the data.

So I dropped in a speed selector that also defaults to the current speed. You can swap to faster or slower speeds. There is 'slow' and 'super slow', 'fast' and 'super fast'. It also supports URL construction/processing as with all the other parameters.

I'm okay if you don't merge the changes, but I feel others might enjoy the choice, hence my PR. If you want to merge the feature, feel free to alter as you see fit before merging.