### PR TITLE
Select countries by increasing / decreasing values

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,9 @@
           <div class="buttonwrapper">
             <button @click="deselectAll" aria-Label="Deselect All Regions">Deselect All</button>
             <button @click="selectAll" aria-Label="Select All Regions">Select All</button>
+            <button @click="selectDecreasing" aria-Label="Select Decreasing Regions">Select Decreasing</button>
+            <button @click="selectIncreasing" aria-Label="Select Increasing Regions">Select Increasing</button>
+
           </div>
 
           <p style="padding-top: 1rem;">Showing {{regionType}} with at least {{minCasesInCountry}} {{selectedData}}</p>

--- a/vue-definitions.js
+++ b/vue-definitions.js
@@ -547,7 +547,21 @@ window.app = new Vue({
       this.selectedCountries = this.countries;
       this.createURL();
     },
+    
+    selectIncreasing() {
+      const reducer = (accumulator, currentValue) => currentValue ? accumulator + currentValue : accumulator;
+      // const topCountries = this.covidData.sort((a, b) => b.slope.slice(this.daysOfIncrease).reduce(reducer) - a.slope.slice(this.daysOfIncrease).reduce(reducer)).slice(0, 9).map(e => e.country);
+      this.selectedCountries = this.covidData.filter((e) => e.cases.length > this.daysOfIncrease ? e.slope.slice(-1 * this.daysOfIncrease).reduce(reducer) > e.slope.slice(-2 * this.daysOfIncrease, -1 * this.daysOfIncrease).reduce(reducer) : false).map((e) => e.country);
+      this.createURL();
+    },
 
+    selectDecreasing() {
+      const reducer = (accumulator, currentValue) => currentValue ? accumulator + currentValue : accumulator;
+      // const topCountries = this.covidData.sort((a, b) => b.slope.slice(this.daysOfIncrease).reduce(reducer) - a.slope.slice(this.daysOfIncrease).reduce(reducer)).slice(0, 9).map(e => e.country);
+      this.selectedCountries = this.covidData.filter((e) => e.cases.length > this.daysOfIncrease ? e.slope.slice(-1 * this.daysOfIncrease).reduce(reducer) <= e.slope.slice(-2 * this.daysOfIncrease, -1 * this.daysOfIncrease).reduce(reducer) : false).map((e) => e.country);
+      this.createURL();
+    },
+    
     deselectAll() {
       this.selectedCountries = [];
       this.createURL();
@@ -955,7 +969,7 @@ window.app = new Vue({
       height: NaN,
       referenceLineAngle: NaN
     },
-
+    daysOfIncrease: 4
   }
 
 });


### PR DESCRIPTION
Users are presumably interested in seeing which regions are currently 'winning' or 'losing' with respect to covid.

I have, therefore, added buttons and methods which will select all of the regions which are going up or down (with respect to the selectedData).

This is done by checking whether the sum of the slope over that last 4 days is more or less than the sum of the slope in the previous 4 days (where the 4 days is stored in the 'daysOfIncrease' variable).

If you adopt this change, it may be desirable to allow users to change the daysOfIncrease variable (as can currently done with doublingTime). I'm happy to make this change (or others) as might be useful.

Thanks for covidtrends - I appreciate it.